### PR TITLE
Fix #107 (Axis’s “Labels" property group layout is broken)

### DIFF
--- a/src/css/inspectors.less
+++ b/src/css/inspectors.less
@@ -80,6 +80,10 @@
     width: 50px;
   }
 
+  input.fontSize {
+    width: 40px;
+  }
+
   span.editVal {
     float: left;
     padding: 5px;

--- a/src/tmpl/inspectors/axis.html
+++ b/src/tmpl/inspectors/axis.html
@@ -52,19 +52,21 @@
                     property="axisStyle.fill" nodrop="1" style="full"
                     ng-model="axis.properties.titleStyle.fill.value" ></vde-property>
     </div>
-
     <h4>Labels</h4>
 
-    <vde-property label="font" type="font" item="axis" property="labelStyle"
-                  ng-model="axis.properties.labelStyle" nodrop="1" style="half"></vde-property>
+      <vde-property label="Font" type="font" item="axis" property="labelStyle"
+                  ng-model="axis.properties.labelStyle" nodrop="1" style="full"></vde-property>
 
-    <vde-property label="angle" type="number" min="-360" max="360"
-                  item="axis" property="labelStyle.angle" nodrop="1"
-                  ng-model="axis.properties.labelStyle.angle.value" style="half"></vde-property>
 
-    <br clear="all" />
+      <br clear="all" />
 
-    <vde-property label="Fill" type="color" item="axis"
+      <vde-property label="Angle" type="number" min="-360" max="360"
+                    item="axis" property="labelStyle.angle" nodrop="1"
+                    ng-model="axis.properties.labelStyle.angle.value" style="full"></vde-property>
+
+      <br clear="all" />
+
+      <vde-property label="Fill" type="color" item="axis"
                   property="labelStyle.fill"
                   ng-model="axis.properties.labelStyle.fill.value"
                   nodrop="1" style="full"></vde-property>


### PR DESCRIPTION
Now (See #107): 
![lyra-31](https://f.cloud.github.com/assets/111269/2223883/d6f07aee-9a77-11e3-9693-7c873301bebb.png)

Also capitalize “F" and “A" in “Font” and “Angle” for you. 

It’s still a bit different from “Text”’s font properties but these properties are not drop zones for Axis so I think this should be fine.  

(Text Font properties)
![lyra-32](https://f.cloud.github.com/assets/111269/2224137/df6e1b56-9a7a-11e3-905c-54fe682f7e75.png)
