### PR TITLE
Default type for domain of a scale

### DIFF
--- a/src/js/vis/Scale.js
+++ b/src/js/vis/Scale.js
@@ -4,13 +4,13 @@ vde.Vis.Scale = (function() {
     this.name  = (name || pipeline.name + '_' + scaleName);
     this.displayName = displayName;
 
-    this.domainTypes = {from: 'field'};  // Field or Values
+    this.domainTypes = {from: 'values'};  // Field or Values
     this.rangeTypes  = {type: 'spatial', from: 'preset'};  // 'property' key if type is 'other'
 
     this.domainField = null;
     this.rangeField  = null;
 
-    this.domainValues = [];
+    this.domainValues = [0, 100]; //set [0, 100] as default value - works for all of quantitative, ordinal, categorical
     this.rangeValues  = [];
 
     this.used = false;    // Auto-delete unused scales


### PR DESCRIPTION
Part of #83.
- A new scale has `domainTypes = values` by default to prevent incomplete specification.  
  (`field` requires user specification)
- set `domainValues = [0,100];` by default

Reseting default value for multiple is more complicated .. I started a bit but I don't it's worth the time doing it now.
