### PR TITLE
align arrows!

### DIFF
--- a/src/css/groups-list.less
+++ b/src/css/groups-list.less
@@ -26,8 +26,11 @@
   h3 span.title { width: 195px; }
   h3 span.spinner-expanded {
     cursor: default;
+    margin-left: -3px;
+    margin-right: 3px;
   }
   h3:hover span.spinner-expanded:hover { color: #000 !important; }
+
   h2, h3 span.spinner-contracted {
     cursor: pointer;
   }


### PR DESCRIPTION
somehow the arrows weren’t aligned due to the arrow characters we use.

![lyra-8](https://f.cloud.github.com/assets/111269/2242604/03f29ef8-9d09-11e3-95fb-52ad45a29edb.png)
