### PR TITLE
Embedding saved timeline object in a list for correct later retrieval

### DIFF
--- a/src/js/app/timeline.js
+++ b/src/js/app/timeline.js
@@ -35,7 +35,7 @@ vde.App.factory('timeline', ["$rootScope", "$timeout", "$indexedDB", "$q",
 
         this.files().upsert({
           fileName: this.fileName,
-          timeline: { vis: vis, app: app },
+          timeline: [{ vis: vis, app: app }],
           currentIdx: this.currentIdx
         }).then(function(e) { deferred.resolve(e); });
 


### PR DESCRIPTION
This fix allows for loading of saved Lyra work sessions.  The infrastructure expects the `timeline` property to be a list (I believe this is the undo stack but I might be wrong about that).  This fix treats the entire saved visualization as a single-step action that can be undone back to the empty canvas.  Without it, we get a type error in the console.
