### PR TITLE
Fix issue in Firefox related to indexDB

### DIFF
--- a/src/js/lib/indexeddb.js
+++ b/src/js/lib/indexeddb.js
@@ -6,7 +6,10 @@
 
 'use strict';
 /** unify browser specific implementations */
-var indexedDB = window.indexedDB||window.mozIndexedDB||window.webkitIndexedDB||window.msIndexedDB;
+/* prevent error in Firefox */
+if(!('indexedDB' in window)) {
+  window.indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+}
 var IDBKeyRange=window.IDBKeyRange||window.mozIDBKeyRange||window.webkitIDBKeyRange||window.msIDBKeyRange;
 
 angular.module('xc.indexedDB', []).provider('$indexedDB', function() {


### PR DESCRIPTION
I got an error in firefox similar to below code

```
TypeError: setting a property that has only a getter
var indexedDB = window.indexedDB||window.mozIndexedDB||window.webkitIndexedDB||w...
```

See to confirm this code the commit https://github.com/axemclion/IndexedDBShim/commit/3b66b42cde1585514b446cbb13c0cca03e42eb77 and also this discussion https://stackoverflow.com/questions/24903851/angular-indexeddb-issues-with-firefox#answer-24922214
