### PR TITLE
localStorage editor mode

### DIFF
--- a/src/js/app/ctrls/timeline.js
+++ b/src/js/app/ctrls/timeline.js
@@ -66,10 +66,17 @@ vde.App.controller('TimelineCtrl', function($scope, $rootScope, $window, timelin
 
   $scope.finishEditing = function() {
     Vis.render().then(function(spec) {
-      $window.opener.postMessage({
+      var msg = {
         timeline: timeline.timeline,
         spec: spec
-      }, $window.location.origin);
+      };
+
+      if($rootScope.tag) {
+        localStorage.setItem($rootScope.tag, JSON.stringify(msg));
+      } else {
+        $window.opener.postMessage(msg, $window.location.origin);
+      }
+
       $window.close();
     });
   };

--- a/src/js/app/ctrls/vde.js
+++ b/src/js/app/ctrls/vde.js
@@ -106,10 +106,10 @@ vde.App.controller('VdeCtrl', function($scope, $rootScope, $window, $timeout,
 
   // Look for editor mode data passed in local storage; if not found there,
   // install an event listener for messages to arrive via postMessage().
-  var tag = queryArguments.editormode;
-  if(tag) {
+  $rootScope.tag = queryArguments.editormode;
+  if($rootScope.tag) {
     var msg = {
-      data: JSON.parse(localStorage.getItem(tag))
+      data: JSON.parse(localStorage.getItem($rootScope.tag))
     };
 
     window.setTimeout(editorModeBootstrap, 1000, msg);


### PR DESCRIPTION
This PR allows Lyra to be booted into editor mode by launching it with a query argument identifying a slot in `localStorage` where the data previously transmitted by `postMessage()` is stored.

This **adds** the `localStorage` functionality without changing the earlier `postMessage()` method.
