### PR TITLE
Consider removing .jsx extensions from require() calls

### DIFF
--- a/src/js/components/ContentEditable.jsx
+++ b/src/js/components/ContentEditable.jsx
@@ -2,7 +2,7 @@
 var dl = require('datalib'),
     React = require('react'),
     ReactDOM = require('react-dom'),
-    SignalValueMixin = require('./mixins/SignalValue.jsx'),
+    SignalValueMixin = require('./mixins/SignalValue'),
     model = require('../model');
 
 var ContentEditable = React.createClass({

--- a/src/js/components/Inspector.jsx
+++ b/src/js/components/Inspector.jsx
@@ -3,7 +3,7 @@ var React = require('react'),
     Mark = require('../model/primitives/marks/Mark'),
     model = require('../model'),
     lookup = model.primitive,
-    From = require('./inspectors/From.jsx');
+    From = require('./inspectors/From');
 
 var Inspector = React.createClass({
   render: function() {
@@ -35,5 +35,5 @@ var Inspector = React.createClass({
 });
 
 module.exports = Inspector;
-Inspector.Rect = require('./inspectors/Rect.jsx');
-Inspector.Symbol = require('./inspectors/Symbol.jsx');
+Inspector.Rect = require('./inspectors/Rect');
+Inspector.Symbol = require('./inspectors/Symbol');

--- a/src/js/components/LayerList.jsx
+++ b/src/js/components/LayerList.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var React = require('react'),
-    ContentEditable = require('./ContentEditable.jsx'),
+    ContentEditable = require('./ContentEditable'),
     model = require('../model'),
     lookup = model.primitive;
 

--- a/src/js/components/ScaleList.jsx
+++ b/src/js/components/ScaleList.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var React = require('react'),
-    ContentEditable = require('./ContentEditable.jsx');
+    ContentEditable = require('./ContentEditable');
 
 var ScaleList = React.createClass({
   select: function(id) {

--- a/src/js/components/Sidebars.jsx
+++ b/src/js/components/Sidebars.jsx
@@ -1,10 +1,10 @@
 'use strict';
 var dl = require('datalib'),
     React = require('react'),
-    PipelineList = require('./pipelines/PipelineList.jsx'),
-    ScaleList = require('./ScaleList.jsx'),
-    LayerList = require('./LayerList.jsx'),
-    Inspector = require('./Inspector.jsx'),
+    PipelineList = require('./pipelines/PipelineList'),
+    ScaleList = require('./ScaleList'),
+    LayerList = require('./LayerList'),
+    Inspector = require('./Inspector'),
     model = require('../model'),
     sg = require('../model/signals'),
     lookup = model.primitive;

--- a/src/js/components/index.jsx
+++ b/src/js/components/index.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var ReactDOM = require('react-dom'),
-    Sidebars = require('./Sidebars.jsx'),
+    Sidebars = require('./Sidebars'),
     React = require('react');
 
 module.exports = ReactDOM.render(

--- a/src/js/components/inspectors/ExtentProperty.jsx
+++ b/src/js/components/inspectors/ExtentProperty.jsx
@@ -1,9 +1,9 @@
 'use strict';
 var dl = require('datalib'),
     React = require('react'),
-    Property = require('./Property.jsx'),
-    SpatialPreset = require('./SpatialPreset.jsx'),
-    Parse = require('../mixins/Parse.jsx'),
+    Property = require('./Property'),
+    SpatialPreset = require('./SpatialPreset'),
+    Parse = require('../mixins/Parse'),
     util = require('../../util'),
     model = require('../../model'),
     lookup = model.primitive;

--- a/src/js/components/inspectors/From.jsx
+++ b/src/js/components/inspectors/From.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var React = require('react'),
-    Property = require('./Property.jsx'),
+    Property = require('./Property'),
     model = require('../../model'),
     lookup = model.primitive;
 

--- a/src/js/components/inspectors/Property.jsx
+++ b/src/js/components/inspectors/Property.jsx
@@ -1,9 +1,9 @@
 'use strict';
 var dl = require('datalib'),
     React = require('react'),
-    Parse = require('../mixins/Parse.jsx'),
-    SignalValue = require('../mixins/SignalValue.jsx'),
-    ContentEditable = require('../ContentEditable.jsx'),
+    Parse = require('../mixins/Parse'),
+    SignalValue = require('../mixins/SignalValue'),
+    ContentEditable = require('../ContentEditable'),
     model = require('../../model'),
     lookup = model.primitive;
 

--- a/src/js/components/inspectors/Rect.jsx
+++ b/src/js/components/inspectors/Rect.jsx
@@ -1,7 +1,7 @@
 'use strict';
 var React = require('react'),
-    Property = require('./Property.jsx'),
-    ExtentProperty = require('./ExtentProperty.jsx');
+    Property = require('./Property'),
+    ExtentProperty = require('./ExtentProperty');
 
 var Rect = React.createClass({
   render: function() {

--- a/src/js/components/inspectors/SpatialPreset.jsx
+++ b/src/js/components/inspectors/SpatialPreset.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var React = require('react'),
-    Parse = require('../mixins/Parse.jsx'),
+    Parse = require('../mixins/Parse'),
     util = require('../../util'),
     model = require('../../model'),
     lookup = model.primitive;

--- a/src/js/components/inspectors/Symbol.jsx
+++ b/src/js/components/inspectors/Symbol.jsx
@@ -1,6 +1,6 @@
 'use strict';
 var React = require('react'),
-    Property = require('./Property.jsx'),
+    Property = require('./Property'),
     Base = require('../../model/primitives/marks/Symbol');
 
 var Symbol = React.createClass({

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -3,7 +3,7 @@ var d3 = require('d3'),
     dl = require('datalib'),
     React = require('react'),
     ReactDOM = require('react-dom'),
-    Parse = require('../mixins/Parse.jsx'),
+    Parse = require('../mixins/Parse'),
     model = require('../../model'),
     sg = require('../../model/signals');
 

--- a/src/js/components/pipelines/PipelineInspector.jsx
+++ b/src/js/components/pipelines/PipelineInspector.jsx
@@ -2,8 +2,8 @@
 var d3 = require('d3'),
     React = require('react'),
     ReactDOM = require('react-dom'),
-    ContentEditable = require('../ContentEditable.jsx'),
-    DataTable = require('./DataTable.jsx');
+    ContentEditable = require('../ContentEditable'),
+    DataTable = require('./DataTable');
 
 var PipelineInspector = React.createClass({
   render: function() {

--- a/src/js/components/pipelines/PipelineList.jsx
+++ b/src/js/components/pipelines/PipelineList.jsx
@@ -1,7 +1,7 @@
 'use strict';
 var d3 = require('d3'),
     React = require('react'),
-    PipelineInspector = require('./PipelineInspector.jsx');
+    PipelineInspector = require('./PipelineInspector');
 
 var PipelineList = React.createClass({
   getInitialState: function() {


### PR DESCRIPTION
By default React eslint rules flag require calls that specify `.jsx`: the rationale from the [`eslint-plugin-react` documentation](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-extension.md) is that,

> `require()` statements should generally not include a file extension as there is a well defined mechanism for resolving a module ID to a specific file.

Our Webpack configuration does handle this resolution so it is accurate that the extension is unneeded.

Removing the .jsx extensions from require calls suppresses 54 errors, but I do not want to make the assumption that changing the code is the way to go: we could also suppress this eslint rule.

There does not seem to be a universal preference about using or omitting the extension, but the majority of coworkers I polled have adopted the extensionless form.

Thoughts on this, @arvind @deathbearbrown?

LYRA-261
