### PR TITLE
[WIP] JSDocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:js": "mocha --timeout 30000 --recursive test/",
     "cover": "npm run cover",
     "cover:js": "istanbul cover _mocha -- --timeout 30000 --recursive test/",
-    "docs": "./node_modules/.bin/jsdoc --configure .jsdoc.json",
+    "docs": "jsdoc --configure .jsdoc.json",
     "start": "webpack-dev-server --inline"
   },
   "dependencies": {

--- a/src/js/components/Inspector.jsx
+++ b/src/js/components/Inspector.jsx
@@ -15,7 +15,7 @@ var Inspector = React.createClass({
         isMark = primitive instanceof Mark;
 
     var pipeline = isMark ? (
-      <From {...props} primitive={primitive} from={primitive.pipeline()} />
+      <From {...props} primitive={primitive} from={primitive.dataset()} />
     ) : null;
 
     var inner = InspectorType ? (

--- a/src/js/components/inspectors/From.jsx
+++ b/src/js/components/inspectors/From.jsx
@@ -4,13 +4,13 @@ var React = require('react'),
 
 var From = React.createClass({
   handleChange: function(evt) {
-    this.props.primitive.pipeline(+evt.target.value);
+    this.props.primitive.dataset(+evt.target.value);
   },
 
   render: function() {
     var props = this.props,
         pipelines = props.pipelines,
-        from = props.from;
+        from = props.from && props.from._id;
 
     return (
       <Property name="pipeline" label="Pipeline">

--- a/src/js/model/index.js
+++ b/src/js/model/index.js
@@ -127,11 +127,11 @@ model.manipulators = function() {
   });
 
   data.push({
-    name: 'dropzone',
-    transform: [{type: util.ns('dropzone')}]
+    name: 'bubble_cursor',
+    transform: [{type: util.ns('bubble_cursor')}]
   });
 
-  marks.push(manips.DROPZONE);
+  marks.push(manips.BUBBLE_CURSOR);
 
   return spec;
 };

--- a/src/js/model/index.js
+++ b/src/js/model/index.js
@@ -90,7 +90,7 @@ model.signal = function() {
 /**
  * Exports the model as a complete Vega specification.
  * @param  {Object}  [scene] - An exported specification of the Scene.
- * @param  {boolean} [clean=true] - Should Lyra-specific definitions be removed
+ * @param  {boolean} [clean=true] - Should Lyra-specific properties be removed
  * or resolved (e.g., converting property signal references to actual values).
  * @return {Object} A Vega specification.
  */

--- a/src/js/model/primitives/Guide.js
+++ b/src/js/model/primitives/Guide.js
@@ -2,8 +2,29 @@ var Primitive = require('./Primitive'),
     model = require('../'),
     lookup = model.primitive;
 
+
 var GTYPES = {AXIS: 1, LEGEND: 2},
     ORIENT = {x: 'bottom', y: 'left'};
+
+/**
+ * @classdesc A Lyra Guide Primitive.
+ *
+ * @description The Guide Primitive corresponds to a definition for a Vega
+ * axis or legend.
+ * @extends {Primitive}
+ *
+ * @param {number} gtype - Axis or Legend (use enumerated `Guide.TYPES`).
+ * @param {string} type - Axis/legend type (e.g., `x` axis, or `fill` legend).
+ * @param {number|Object} scale - The ID or Lyra Scale Primitive that backs the guide.
+ *
+ * @property {number} _gtype - Axis or Legend (based on enumerate `Guide.TYPES`).
+ * @property {string} _type - Type for legends (e.g., `fill`, `stroke`, etc.).
+ * @see Vega's {@link https://github.com/vega/vega/wiki/Axes|Axes} or
+ * {@link https://github.com/vega/vega/wiki/Legends|Legends} documentation for
+ * more information on this class' "public" properties.
+ *
+ * @constructor
+ */
 function Guide(gtype, type, scale) {
   this._gtype = gtype;
 
@@ -36,16 +57,16 @@ function Guide(gtype, type, scale) {
   return Primitive.call(this);
 }
 
-var prototype = (Guide.prototype = Object.create(Primitive.prototype));
-prototype.constructor = Guide;
+Guide.prototype = Object.create(Primitive.prototype);
+Guide.prototype.constructor = Guide;
 
 // TODO: Map guide properties to signals.
-prototype.init = function() {
+Guide.prototype.init = function() {
   return this;
 };
 
-prototype.export = prototype.manipulators = function(resolve) {
-  var spec = Primitive.prototype.export.call(this, resolve),
+Guide.prototype.export = Guide.prototype.manipulators = function(clean) {
+  var spec = Primitive.prototype.export.call(this, clean),
       gtype = this._gtype,
       type = this._type;
 

--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -4,6 +4,27 @@ var dl = require('datalib'),
     lookup = model.primitive,
     names = {};
 
+/**
+ * @classdesc A Lyra Scale Primitive.
+ *
+ * @description The Scale Primitive corresponds to a definition for a Vega scale.
+ * @extends {Primitive}
+ *
+ * @param {string} name - The initial name of the scale. It may be renamed to
+ * prevent scale name collisions.
+ * @param {string} type - The scale type (e.g., `ordinal`, `linear`, etc.).
+ * @param {*} domain - The scale domain (values in data space).
+ * @param {*} range - The scale range (values in visual space, e.g., `width`).
+ *
+ * @property {number[]} _domain - An array of primitive IDs if the scale's
+ * domain is a set of fields (a Vega {@link https://github.com/vega/vega/wiki/Scales#scale-domains|DataRef}).
+ * @property {number[]} _range - An array of primitive IDs if the scale's
+ * range is a set of fields (a Vega {@link https://github.com/vega/vega/wiki/Scales#scale-domains|DataRef}).
+ * @see Vega's {@link https://github.com/vega/vega/wiki/Scales|Scales}
+ * documentation for more information on this class' "public" properties.
+ *
+ * @constructor
+ */
 function Scale(name, type, domain, range) {
   this.name = rename(name);
   this.type = type;
@@ -20,9 +41,9 @@ function Scale(name, type, domain, range) {
   return Primitive.call(this);
 }
 
-var prototype = (Scale.prototype = Object.create(Primitive.prototype));
-prototype.constructor = Scale;
-prototype.parent = null;
+Scale.prototype = Object.create(Primitive.prototype);
+Scale.prototype.constructor = Scale;
+Scale.prototype.parent = null;
 
 // To prevent name collisions.
 function rename(name) {
@@ -74,7 +95,7 @@ function dataRef(ref) {
   }
 }
 
-prototype.export = prototype.manipulators = function(resolve) {
+Scale.prototype.export = Scale.prototype.manipulators = function(resolve) {
   var spec = Primitive.prototype.export.call(this, resolve);
 
   if (!this.domain && this._domain.length) {

--- a/src/js/model/primitives/data/Field.js
+++ b/src/js/model/primitives/data/Field.js
@@ -3,6 +3,27 @@ var dl = require('datalib'),
     Primitive = require('../Primitive'),
     TYPES = vl.data.types;
 
+/**
+ * @classdesc A Lyra Data Field Primitive.
+ * @description  This class does not have a corresponding Vega definition.
+ * However, treating fields as a first-class Primitive in Lyra is useful for
+ * a variety of reasons (e.g., storing type and aggregate information).
+ * @extends {Primitive}
+ *
+ * @param {string} name - The name of the field.
+ * @param {string} ptype - The JavaScript primitive type of the field
+ * (boolean, string, etc.).
+ *
+ * @property {string} _name - The name of the field.
+ * @property {string} _ptype - The JavaScript primitive type of the field
+ * (boolean, string, etc.).
+ * @property {string} _type - The data type (nominal, ordinal, quantitative, temporal).
+ * @property {*} _aggregate TBD.
+ * @property {*} _bin TBD.
+ * @property {Function} $ - An accessor function for the field.
+ *
+ * @constructor
+ */
 function Field(name, ptype) {
   this._name = name;
   this._ptype = ptype;         // primitive type (boolean/string/etc.)
@@ -16,10 +37,15 @@ function Field(name, ptype) {
   return Primitive.call(this);
 }
 
-var prototype = (Field.prototype = Object.create(Primitive.prototype));
-prototype.constructor = Field;
+Field.prototype = Object.create(Primitive.prototype);
+Field.prototype.constructor = Field;
 
-prototype.profile = function(p) {
+/**
+ * Gets/sets the Field's statistical profile. If one does not exist, calls
+ * its {@link Dataset#summary|Dataset's profiler} first.
+ * @return {Object} The Field's summary profile.
+ */
+Field.prototype.profile = function(p) {
   if (p !== undefined) {
     return (this._profile = p, this);
   }

--- a/src/js/model/primitives/data/Pipeline.js
+++ b/src/js/model/primitives/data/Pipeline.js
@@ -1,6 +1,21 @@
 var Primitive = require('../Primitive'),
     Dataset = require('./Dataset');
 
+/**
+ * @classdesc A Lyra Pipeline Primitive.
+ * @description  This class does not have a corresponding Vega definition.
+ * A Pipeline comprises several related Datasets (that may be grouped together
+ * in the Lyra UI).
+ *
+ * @param {string} name - The name of the pipeline
+ *
+ * @property {Object} _source - The source {@link Dataset} of the pipeline. All
+ * other {@link Dataset|Datasets} in the pipeline must be derived from this.
+ * @property {Object[]} _aggregates TBD - Possible an array of derived Datasets
+ * to compute aggregation?
+ *
+ * @constructor
+ */
 function Pipeline(name) {
   Primitive.call(this);
   this.name = name;
@@ -9,13 +24,19 @@ function Pipeline(name) {
   return this;
 }
 
-var prototype = (Pipeline.prototype = Object.create(Primitive.prototype));
-prototype.constructor = Pipeline;
-prototype.parent = null;
+Pipeline.prototype = Object.create(Primitive.prototype);
+Pipeline.prototype.constructor = Pipeline;
+Pipeline.prototype.parent = null;
 
-prototype.export = function(resolve) {
-  return [this._source.export(resolve)]
-    .concat(this._aggregates.map(function(a) { return a.export(resolve); }));
+/**
+ * Exports each of the constituent {@link Dataset|Datasets}.
+ * @param  {boolean} [clean=true] - Should Lyra-specific properties be removed
+ * or resolved (e.g., converting property signal references to actual values).
+ * @return {Object[]} An array of Vega data source specifications.
+ */
+Pipeline.prototype.export = function(clean) {
+  return [this._source.export(clean)]
+    .concat(this._aggregates.map(function(a) { return a.export(clean); }));
 };
 
 module.exports = Pipeline;

--- a/src/js/model/primitives/marks/Group.js
+++ b/src/js/model/primitives/marks/Group.js
@@ -12,8 +12,18 @@ var CHILDREN = {
   rect:   require('./Rect'),
   symbol: require('./Symbol'),
   scales: require('../Scale'),
+  legends: require('../Guide'),
+  axes: require('../Guide')
 };
 
+/**
+ * @classdesc A Lyra Group Mark Primitive.
+ * @extends {Mark}
+ * @see  Vega's {@link https://github.com/vega/vega/wiki/Group-Marks|Group Marks}
+ * documentation for more information on this class' "public" properties.
+ *
+ * @constructor
+ */
 function Group() {
   Mark.call(this, 'group');
 
@@ -34,10 +44,10 @@ function Group() {
   return this;
 }
 
-var prototype = (Group.prototype = Object.create(Mark.prototype));
-prototype.constructor = Group;
+Group.prototype = Object.create(Mark.prototype);
+Group.prototype.constructor = Group;
 
-prototype.export = function(resolve) {
+Group.prototype.export = function(resolve) {
   var self = this,
       spec = Mark.prototype.export.call(this, resolve),
       fn = function(id) { return lookup(id).export(resolve); };
@@ -46,7 +56,7 @@ prototype.export = function(resolve) {
   return spec;
 };
 
-prototype.manipulators = function() {
+Group.prototype.manipulators = function() {
   var self = this,
       spec = Mark.prototype.manipulators.call(this),
       group = spec[0],
@@ -61,8 +71,16 @@ prototype.manipulators = function() {
   return spec;
 };
 
-// Insert or create a child element.
-prototype.child = function(type, child) {
+/**
+ * Insert or create a child Primitive.
+ * @param  {string} type - The type of the child (`scales`, `axes`, `legends`).
+ * For marks, this should also include the mark type (e.g., `marks.rect`).
+ * @param  {number|Object} [child] - The ID or Primitive corresponding to the
+ * child to be inserted into the Group. If no child is specified, a new one
+ * is created and initialized.
+ * @return {Object} The child Primitive.
+ */
+Group.prototype.child = function(type, child) {
   type = type.split('.');
   child = (child === undefined) ? new CHILDREN[type[1] || type[0]]().init() :
     dl.isNumber(child) ? lookup(child) : child;

--- a/src/js/model/primitives/marks/Rect.js
+++ b/src/js/model/primitives/marks/Rect.js
@@ -7,7 +7,13 @@ var DELTA = sg.DELTA,
     DX = DELTA + '.x',
     DY = DELTA + '.y';
 
-function Rect(type) {
+/**
+ * @classdesc A Lyra Rect Mark Primitive.
+ * @extends {Mark}
+ *
+ * @constructor
+ */
+function Rect() {
   Mark.call(this, 'rect');
 
   var props = this.properties,
@@ -25,10 +31,10 @@ function Rect(type) {
   return this;
 }
 
-var prototype = (Rect.prototype = Object.create(Mark.prototype));
-prototype.constructor = Rect;
+Rect.prototype = Object.create(Mark.prototype);
+Rect.prototype.constructor = Rect;
 
-prototype.initHandles = function() {
+Rect.prototype.initHandles = function() {
   var prop = util.propSg,
       test = util.test,
       at = util.anchorTarget.bind(util, this, 'handles'),

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -3,6 +3,17 @@ var sg = require('../../signals'),
 
 var SG_WIDTH = 'vis_width', SG_HEIGHT = 'vis_height';
 
+/**
+ * @classdesc A Lyra Scene Primitive.
+ * @description  This class corresponds to the root of a Vega specification.
+ * @extends {Mark}
+ *
+ * @see  Vega's {@link https://github.com/vega/vega/wiki/Visualization|top-level
+ * Visualization} documentation for more information on this class' "public"
+ * properties.
+ *
+ * @constructor
+ */
 function Scene() {
   Group.call(this);
 
@@ -14,17 +25,17 @@ function Scene() {
   return this;
 }
 
-var prototype = (Scene.prototype = Object.create(Group.prototype));
-prototype.constructor = Scene;
-prototype.parent = null;
+Scene.prototype = Object.create(Group.prototype);
+Scene.prototype.constructor = Scene;
+Scene.prototype.parent = null;
 
-prototype.init = function() {
+Scene.prototype.init = function() {
   this.width = sg.init(SG_WIDTH, this.width);
   this.height = sg.init(SG_HEIGHT, this.height);
   return Group.prototype.init.call(this);
 };
 
-prototype.export = function(resolve) {
+Scene.prototype.export = function(resolve) {
   var spec = Group.prototype.export.call(this, resolve);
 
   // Always resolve width/height signals.
@@ -39,7 +50,7 @@ prototype.export = function(resolve) {
   return spec;
 };
 
-prototype.manipulators = function() {
+Scene.prototype.manipulators = function() {
   return Group.prototype.manipulators.call(this)[0];
 };
 

--- a/src/js/model/primitives/marks/Symbol.js
+++ b/src/js/model/primitives/marks/Symbol.js
@@ -7,7 +7,13 @@ var DELTA = sg.DELTA,
     DX = DELTA + '.x',
     DY = DELTA + '.y';
 
-function Symbol(type) {
+/**
+ * @classdesc A Lyra Symbol Mark Primitive.
+ * @extends {Mark}
+ *
+ * @constructor
+ */
+function Symbol() {
   Mark.call(this, 'symbol');
 
   var props = this.properties,
@@ -21,10 +27,10 @@ function Symbol(type) {
   return this;
 }
 
-var prototype = (Symbol.prototype = Object.create(Mark.prototype));
-prototype.constructor = Symbol;
+Symbol.prototype = Object.create(Mark.prototype);
+Symbol.prototype.constructor = Symbol;
 
-prototype.initHandles = function() {
+Symbol.prototype.initHandles = function() {
   var prop = util.propSg,
       test = util.test,
       at = util.anchorTarget.bind(util, this, 'handles'),

--- a/src/js/model/primitives/marks/manipulators.js
+++ b/src/js/model/primitives/marks/manipulators.js
@@ -176,9 +176,9 @@ TYPES.push(manipulators.SPAN = dl.extend({}, manipulators.ARROW, {
   }
 }));
 
-manipulators.DROPZONE = {
+manipulators.BUBBLE_CURSOR = {
   type: 'line',
-  from: {data: 'dropzone'},
+  from: {data: 'bubble_cursor'},
   properties: {
     update: {
       x: {field: 'x'},

--- a/src/js/model/rules/marks.js
+++ b/src/js/model/rules/marks.js
@@ -10,7 +10,7 @@ module.exports = function(parsed, property, channel) {
       from;
 
   if (def.from && def.from.data) {
-    this.pipeline(map.data[def.from.data]);
+    this.dataset(map.data[def.from.data]);
     from = lookup(this.from);
   }
 

--- a/src/js/transforms/BubbleCursor.js
+++ b/src/js/transforms/BubbleCursor.js
@@ -7,12 +7,8 @@ var dl = require('datalib'),
     Transform = vg.Transform,
     sg = require('../model/signals');
 
-
-DropZone.prototype = Object.create(Transform.prototype);
-DropZone.prototype.constructor = DropZone;
-
 /**
- * @classdesc Represents a DropZone.
+ * @classdesc Represents a BubbleCursor.
  *
  * @description Creates a new drop zone
  * @param {string} graph - model
@@ -26,7 +22,7 @@ DropZone.prototype.constructor = DropZone;
  *
  * @constructor
  */
-function DropZone(graph) {
+function BubbleCursor(graph) {
   Transform.prototype.init.call(this, graph);
   this._cellID = null;
   this._cache = [];
@@ -37,12 +33,15 @@ function DropZone(graph) {
     .dependency(Deps.SIGNALS, [sg.CELL, sg.MOUSE]);
 }
 
+BubbleCursor.prototype = Object.create(Transform.prototype);
+BubbleCursor.prototype.constructor = BubbleCursor;
+
 /**
- * transform dropzone
+ * transform BubbleCursor
  * @param {string} input - todo.
  * @return {object} output - todo
  */
-DropZone.prototype.transform = function(input) {
+BubbleCursor.prototype.transform = function(input) {
   var g = this._graph,
       cell = g.signal(sg.CELL).value(),
       mouse = g.signal(sg.MOUSE).value(),
@@ -108,4 +107,4 @@ DropZone.prototype.transform = function(input) {
   return output;
 };
 
-module.exports = DropZone;
+module.exports = BubbleCursor;

--- a/src/js/transforms/BubbleCursor.js
+++ b/src/js/transforms/BubbleCursor.js
@@ -8,17 +8,22 @@ var dl = require('datalib'),
     sg = require('../model/signals');
 
 /**
- * @classdesc Represents a BubbleCursor.
+ * @classdesc Represents the BubbleCursor, a Vega data transformation operator.
  *
- * @description Creates a new drop zone
- * @param {string} graph - model
- * @returns  router ?
+ * @description The BubbleCursor transform uses the user's mouse position
+ * and a voronoi tessellation computed for the current Lyra manipulator type to
+ * indicate which manipulator is currently selected. This is indicated on the
+ * visualization with a salmon shaded region.
  *
- * @property {string} _cellID
- * @property {string} _cache
- * @property {string} _start
- * @property {string} _end
- * @property {string} _mouse
+ * @param {string} graph - A Vega model.
+ * @returns {Object} A Vega-Dataflow Node.
+ *
+ * @property {number} _cellID - The ID of voronoi cell the mouse is over.
+ * @property {Object[]} _cache - A cache of previously calculated bubble cursor
+ * coordinates which is reused if the transform is reevaluated for the same cell.
+ * @property {Object} _start - The first coordinate of the bubble cursor region.
+ * @property {Object} _end - The last coordinate of the bubble cursor region.
+ * @property {Object} _mouse - The user's current mouse position.
  *
  * @constructor
  */
@@ -37,9 +42,10 @@ BubbleCursor.prototype = Object.create(Transform.prototype);
 BubbleCursor.prototype.constructor = BubbleCursor;
 
 /**
- * transform BubbleCursor
- * @param {string} input - todo.
- * @return {object} output - todo
+ * The transform method is automatically called by Vega whenever the bubble
+ * cursor region needs to be recalculated (e.g., when the user moves the mouse).
+ * @param {Object} input - A Vega-Dataflow ChangeSet.
+ * @return {Object} output - A Vega-Dataflow ChangeSet.
  */
 BubbleCursor.prototype.transform = function(input) {
   var g = this._graph,

--- a/src/js/transforms/index.js
+++ b/src/js/transforms/index.js
@@ -9,6 +9,6 @@ t[MANIPULATORS + 'rect'] = require('./manipulators/Rect');
 t[MANIPULATORS + 'group'] = require('./manipulators/Rect');
 t[MANIPULATORS + 'symbol'] = require('./manipulators/Symbol');
 
-t[util.ns('dropzone')] = require('./DropZone');
+t[util.ns('bubble_cursor')] = require('./BubbleCursor');
 
 dl.extend(vg.transforms, t);

--- a/src/js/transforms/manipulators/Manipulators.js
+++ b/src/js/transforms/manipulators/Manipulators.js
@@ -11,6 +11,27 @@ var dl = require('datalib'),
     $x = dl.$('x'),
     $y = dl.$('y');
 
+/**
+ * @classdesc Represents the Manipulators, a Vega data transformation operator.
+ *
+ * @description The Manipulators transform is a base class that should be
+ * subclassed for each mark type. It provides the base transform methods that
+ * compute the data to drive the manipulator mark specifications when in a
+ * particular manipulator mode for a selected visualization mark item.
+ *
+ * @param {string} graph - A Vega model.
+ * @returns {Object} A Vega-Dataflow Node.
+ *
+ * @property {number} _cacheID - The ID the selected mark item from the previous
+ * evaluation.
+ * @property {string} _cacheMode - The manipulator mode from the previous
+ * evaluation.
+ * @property {Object[]} _cache - A cache of previously calculated coordinates
+ * for the corresponding _cacheID and _cacheMode.
+ * @property {Object} _voronoi - A Vega Voronoi data transformation.
+ *
+ * @constructor
+ */
 function Manipulators(graph) {
   Transform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
@@ -26,10 +47,16 @@ function Manipulators(graph) {
     .dependency(Deps.SIGNALS, [sg.SELECTED, sg.MODE]);
 }
 
-var prototype = (Manipulators.prototype = Object.create(Transform.prototype));
-prototype.constructor = Manipulators;
+Manipulators.prototype = Object.create(Transform.prototype);
+Manipulators.prototype.constructor = Manipulators;
 
-prototype.transform = function(input) {
+/**
+ * The transform method is automatically called by Vega whenever the manipulator
+ * coordinates need to be recalculated (e.g., when a new mark item is selected).
+ * @param {Object} input - A Vega-Dataflow ChangeSet.
+ * @return {Object} output - A Vega-Dataflow ChangeSet.
+ */
+Manipulators.prototype.transform = function(input) {
   var g = this._graph,
       item = g.signal(sg.SELECTED).value(),
       mode = g.signal(sg.MODE).value(),
@@ -87,9 +114,40 @@ prototype.transform = function(input) {
     .batchTransform(output, cache);
 };
 
-prototype.handles = function(item) { return []; };
-prototype.connectors = function(item) { return []; };
-prototype.channels = function(item) { return []; };
-prototype.altchannels = function(item) { return []; };
+/**
+ * Calculates the coordinates when in the `handles` manipulators mode.
+ * @param  {Object} item - The Vega-Scenegraph Item corresponding to the
+ * currently selected visualization mark instance.
+ * @return {Object[]} An array of objects, containing the coordinates and other
+ * metadata for downstream manipulator mark specifications.
+ */
+Manipulators.prototype.handles = function(item) { return []; };
+
+/**
+ * Calculates the coordinates when in the `connectors` manipulators mode.
+ * @param  {Object} item - The Vega-Scenegraph Item corresponding to the
+ * currently selected visualization mark instance.
+ * @return {Object[]} An array of objects, containing the coordinates and other
+ * metadata for downstream manipulator mark specifications.
+ */
+Manipulators.prototype.connectors = function(item) { return []; };
+
+/**
+ * Calculates the coordinates when in the `channels` manipulators mode.
+ * @param  {Object} item - The Vega-Scenegraph Item corresponding to the
+ * currently selected visualization mark instance.
+ * @return {Object[]} An array of objects, containing the coordinates and other
+ * metadata for downstream manipulator mark specifications.
+ */
+Manipulators.prototype.channels = function(item) { return []; };
+
+/**
+ * Calculates the coordinates when in the `altchannels` manipulators mode.
+ * @param  {Object} item - The Vega-Scenegraph Item corresponding to the
+ * currently selected visualization mark instance.
+ * @return {Object[]} An array of objects, containing the coordinates and other
+ * metadata for downstream manipulator mark specifications.
+ */
+Manipulators.prototype.altchannels = function(item) { return []; };
 
 module.exports = Manipulators;

--- a/src/js/transforms/manipulators/Rect.js
+++ b/src/js/transforms/manipulators/Rect.js
@@ -7,19 +7,28 @@ var dl = require('datalib'),
     SP = CONST.STROKE_PADDING,
     A = CONST.ARROWHEAD;
 
+/**
+ * @classdesc Represents the RectManipulators, a Vega data transformation operator.
+ *
+ * @description The RectManipulators calculates manipulators when a rect mark
+ * instance is selected.
+ * @extends Manipulators
+ *
+ * @constructor
+ */
 function RectManipulators(graph) {
   return Base.call(this, graph);
 }
 
-var prototype = (RectManipulators.prototype = Object.create(Base.prototype));
-prototype.constructor = RectManipulators;
+RectManipulators.prototype = Object.create(Base.prototype);
+RectManipulators.prototype.constructor = RectManipulators;
 
-prototype.handles = function(item) {
+RectManipulators.prototype.handles = function(item) {
   var c = spec.coords(item.bounds, 'handle');
   return dl.vals(c).filter(function(x) { return x.key !== 'midCenter'; });
 };
 
-prototype.connectors = function(item) {
+RectManipulators.prototype.connectors = function(item) {
   return dl.vals(spec.coords(item.bounds, 'connector'));
 };
 
@@ -31,7 +40,7 @@ function map(key, manipulator) {
   };
 }
 
-prototype.channels = function(item) {
+RectManipulators.prototype.channels = function(item) {
   var b = item.bounds,
       c = spec.coords(b),
       tl = c.topLeft,
@@ -54,7 +63,7 @@ prototype.channels = function(item) {
     ].map(map('y+', 'arrow')));
 };
 
-prototype.altchannels = function(item) {
+RectManipulators.prototype.altchannels = function(item) {
   var b = item.bounds,
       gb = item.mark.group.bounds,
       c = spec.coords(b),

--- a/src/js/transforms/manipulators/Symbol.js
+++ b/src/js/transforms/manipulators/Symbol.js
@@ -5,14 +5,23 @@ var Base = require('./Manipulators'),
     PX = CONST.PADDING,
     SP = CONST.STROKE_PADDING;
 
+/**
+ * @classdesc Represents the SymbolManipulators, a Vega data transformation operator.
+ *
+ * @description The SymbolManipulators calculates manipulators when a symbol
+ * mark instance is selected.
+ * @extends Manipulators
+ *
+ * @constructor
+ */
 function SymbolManipulators(graph) {
   return Base.call(this, graph);
 }
 
-var prototype = (SymbolManipulators.prototype = Object.create(Base.prototype));
-prototype.constructor = SymbolManipulators;
+SymbolManipulators.prototype = Object.create(Base.prototype);
+SymbolManipulators.prototype.constructor = SymbolManipulators;
 
-prototype.handles = function(item) {
+SymbolManipulators.prototype.handles = function(item) {
   var c = spec.coords(item.bounds, 'handle');
   return [
     c.topLeft, c.topRight,
@@ -20,7 +29,7 @@ prototype.handles = function(item) {
   ];
 };
 
-prototype.connectors = function(item) {
+SymbolManipulators.prototype.connectors = function(item) {
   var c = spec.coords(item.bounds, 'connector');
   return [c.midCenter];
 };
@@ -33,7 +42,7 @@ function map(key, manipulator) {
   };
 }
 
-prototype.channels = prototype.altchannels = function(item) {
+SymbolManipulators.prototype.channels = function(item) {
   var b = item.bounds,
       gb = item.mark.group.bounds,
       c = spec.coords(b),
@@ -50,4 +59,5 @@ prototype.channels = prototype.altchannels = function(item) {
     ].map(map('y', 'span')));
 };
 
+SymbolManipulators.prototype.altchannels = SymbolManipulators.prototype.channels;
 module.exports = SymbolManipulators;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -4,37 +4,35 @@ var dl = require('datalib'),
     NS = 'lyra_',
     vgSchema;
 
-function ns (name) {
+function ns(name) {
   return name.startsWith(NS) ? name : NS+name;
 };
 
 /** @namespace */
 var util = {
 /**
- * ns
- * add description
- * @param {string} name - todo.
+ * Ensure an input string is in the Lyra namespace.
+ * @param {string} name - Input string to namespace.
  */
   ns: ns,
 
 /**
- * Util#propSq
- * add description
- * @param {string} mark - todo.
- * @param {string} p - todo.
+ * Returns the signal name corresponding to the given mark and property.
+ * @param {Object} mark - A Mark object.
+ * @param {string} property - The name of the property.
+ * @return {string} The name of the signal for the given mark's property.
  */
-  propSg: function(mark, p) {
-    return ns(mark.type + '_' + mark._id + '_' + p);
+  propSg: function(mark, property) {
+    return ns(mark.type + '_' + mark._id + '_' + property);
   },
 
 /**
- * Util#anchorTarget
- * Returns an expr str condition that tests whether the anchor target
+ * Returns a Vega expression string that tests whether the anchor target
  * has a particular key or is a scenegraph item itself.
- * @constructor
- * @param {string} mark - todo.
- * @param {string} mode - todo.
- * @param {string} key - todo.
+ * @param {Object} mark - A Mark object.
+ * @param {string} mode - The Lyra manipulator mode.
+ * @param {string} [key] - The key of a specific manipulator instance.
+ * @return {string} A Vega expression string.
  */
   anchorTarget: function(mark, mode, key) {
     var sg = require('./model/signals'),
@@ -53,19 +51,18 @@ var util = {
   },
 
 /**
- * Util#test
- * Returns ...
- * @param {string} condition - todo.
- * @param {string} t - todo.
- * @param {string} f - todo.
+ * Returns a Vega if-expression string.
+ * @param {string} pred - The predicate string.
+ * @param {string} t - The true condition string.
+ * @param {string} f - The false condition string.
+ * @return {string} A Vega if-expression string.
  */
-  test: function(cond, t, f) {
-    return 'if(' + cond + ',' + t + ',' + f + ')';
+  test: function(pred, t, f) {
+    return 'if(' + pred + ',' + t + ',' + f + ')';
   },
 
 /**
- * Util#schema
- * Returns vega-schema
+ * @return {Object} The Vega JSON schema.
  */
   schema: function() {
     return vgSchema || (vgSchema = vg.schema({


### PR DESCRIPTION
This adds documentation for the majority of the non-JSX source code. There are three pending areas that need to be documented:
- [ ] `model/signals`
- [ ] `model/rules`
- [ ] `model/primitives/marks/manipulators`

For the latter two, I wasn't entirely sure which JSDoc tag I should be using since both of those extend the `Mark` prototype. It's not exactly an `@interface` and using `@memberof` suggests that they're static members, which they're not. 

It might, of course, be a sign that there's no good JSDoc tag to describe that design pattern. So perhaps they need to be refactored and moved into `Mark` proper? The reason they are where they are now, though, is I felt it better encapsulated functionality (i.e., all `rules` logic together, and all `manipulators` logic together rather than spread across different modules).
