### PR TITLE
Add a local development server using webpack-dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,10 @@ To build the application itself, execute the build command:
 npm run build
 ```
 
-Lyra is now ready to run. Start a local webserver in the project directory. Example web server commands:
+Lyra is now ready to run. Start the local webserver with the command:
 
 ```sh
-# If you have Python installed,
-python -m SimpleHTTPServer 8001
-
-# PHP
-php -S 127.0.0.1:8001
-
-# Node "serve" package
-npm install -g serve # only needs to be run once
-serve . -p 8001
+npm start
 ```
 
-Lyra can now be loaded in your web browser at http://localhost:8001
+Lyra should now be running at [http://localhost:8080](http://localhost:8080)! This web server will auto-reload when you change the JavaScript code; manually re-building with `npm run build` should only be necessary if you update the SCSS stylesheets.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "uglify-js": "^2.4.24",
     "vega": "^2.5.0",
     "vega-lite": "^1.0.1",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "webpack-dev-server": "^1.14.1"
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx src",
@@ -71,7 +72,8 @@
     "test:js": "mocha --timeout 30000 --recursive test/",
     "cover": "npm run cover",
     "cover:js": "istanbul cover _mocha -- --timeout 30000 --recursive test/",
-    "docs": "./node_modules/.bin/jsdoc --configure .jsdoc.json"
+    "docs": "./node_modules/.bin/jsdoc --configure .jsdoc.json",
+    "start": "webpack-dev-server --inline"
   },
   "dependencies": {
     "jsdoc": "^3.4.0"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,9 @@ module.exports = {
     ],
   },
   output: {
-    filename: path.resolve( __dirname, 'build/js/lyra.js' )
+    path: path.resolve( __dirname, 'build' ),
+    publicPath: '/build/',
+    filename: 'js/lyra.js'
   },
   module: {
     loaders: [
@@ -40,7 +42,7 @@ module.exports = {
     // Extract the "vendor" code into
     new webpack.optimize.CommonsChunkPlugin(
       'vendor', // chunk name
-      path.resolve( __dirname, 'build/js/vendor.js' ) // filename
+      'js/vendor.js' // filename
     )
   ]
 };


### PR DESCRIPTION
`npm start` will spin up a local server at localhost:8080; any JS changes to the files specified in the webpack config will trigger a reload. This sets us up to add hot module replacement down the road.

Changes proposed in this pull request:

**Specify path and publicPath in webpack.config.js**

The "path" specified in the webpack config is the output directory (on disk) for all build files. The "publicPath" is the server-relative path to those files from the context of the webpack dev server.

**Add a "start" package script**

This invokes the webpack dev server with the [`--inline` automatic refresh mode](https://webpack.github.io/docs/webpack-dev-server.html#inline-mode)

**Update local server references in the README**

Static server instructions are no longer necessary; `npm start` will work across platforms without configuration. (I will test in Windows shortly!)
### Steps to functionally test this:
1. `npm install` the Lyra project
2. Run `npm build:scss`
3. Run `npm start`
4. Confirm Lyra is available at http://localhost:8080
5. Confirm that Lyra automatically reloads when changes are made to the JS application source

LYRA-260
