### PR TITLE
Support sourcemaps in webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cover": "npm run cover",
     "cover:js": "istanbul cover _mocha -- --timeout 30000 --recursive test/",
     "docs": "jsdoc --configure .jsdoc.json",
-    "start": "webpack-dev-server --inline"
+    "start": "webpack-dev-server --devtool=cheap-module-source-map --inline"
   },
   "dependencies": {
     "jsdoc": "^3.4.0"


### PR DESCRIPTION
**Description of the problem this pull request fixes**

I neglected to set the webpack dev server to output sourcemaps, which renders it less than useful for development and debugging purposes. Based on the matrix of utility to build performance for each sourcemap method supported by the server, I've opted to implement the "cheap module source map" option, which provides line numbers but not column information within a line.

[Matrix of webpack-dev-server devtool options](https://webpack.github.io/docs/configuration.html#devtool), with selected option called out in bold:

| devtool | build speed | rebuild speed | production supported | quality |
| --- | --- | --- | --- | --- |
| eval | +++ | +++ | no | generated code |
| cheap-eval-source-map | + | ++ | no | transformed code (lines only) |
| cheap-source-map | + | o | yes | transformed code (lines only) |
| cheap-module-eval-source-map | o | ++ | no | original source (lines only) |
| **cheap-module-source-map** | **o** | **-** | **yes** | **original source (lines only)** |
| eval-source-map | -- | + | no | original source |
| source-map | -- | -- | yes | original source |
