### PR TITLE
Standardize curly brace usage across project

### DIFF
--- a/eslint/eslint-defaults.yml
+++ b/eslint/eslint-defaults.yml
@@ -136,8 +136,8 @@ rules:
     - never
   brace-style:
     - 2
-    - stroustrup
-    - allowSingleLine: true
+    - 1tbs
+    - allowSingleLine: false
   camelcase:
     - 2
     - properties: never

--- a/src/js/components/ContentEditable.jsx
+++ b/src/js/components/ContentEditable.jsx
@@ -19,7 +19,9 @@ var ContentEditable = React.createClass({
   },
 
   componentDidUpdate: function() {
-    if (this.state.edit) this._el.focus();
+    if (this.state.edit) {
+      this._el.focus();
+    }
   },
 
   start: function() {
@@ -29,7 +31,9 @@ var ContentEditable = React.createClass({
   stop: function() {
     this.setState({edit: false});
     var obj = this.props.obj;
-    if (!obj) return;
+    if (!obj) {
+      return;
+    }
 
     var Sidebars = require('./');
     if (Sidebars.state.selected === obj._id) {

--- a/src/js/components/inspectors/ExtentProperty.jsx
+++ b/src/js/components/inspectors/ExtentProperty.jsx
@@ -41,9 +41,15 @@ var ExtentProperty = React.createClass({
 
     extents.forEach(function(x) {
       var name = x.name, prop = update[name];
-      if (prop._disabled) return;
-      else if (!start) start = name;
-      else if (start !== name) end = name;
+      if (prop._disabled) {
+        return;
+      }
+      else if (!start) {
+        start = name;
+      }
+      else if (start !== name) {
+        end = name;
+      }
     });
 
     return {start: start, end: end};

--- a/src/js/components/inspectors/Property.jsx
+++ b/src/js/components/inspectors/Property.jsx
@@ -91,11 +91,17 @@ var Property = React.createClass({
     }
 
     var className = 'property';
-    if (props.canDrop) className += ' can-drop';
-    if (extraEl) className += ' extra';
+    if (props.canDrop) {
+      className += ' can-drop';
+    }
+    if (extraEl) {
+      className += ' extra';
+    }
 
     var indicatorClass = 'indicator';
-    if (scale || field) indicatorClass += ' fa fa-times';
+    if (scale || field) {
+      indicatorClass += ' fa fa-times';
+    }
 
     return (
       <div className={className}>

--- a/src/js/components/inspectors/SpatialPreset.jsx
+++ b/src/js/components/inspectors/SpatialPreset.jsx
@@ -38,7 +38,9 @@ var SpatialPreset = React.createClass({
         scale = prop.scale && lookup(prop.scale),
         preset = name.indexOf('x') >= 0 ? 'Width' : 'Height';
 
-    if (prop.field) return null;
+    if (prop.field) {
+      return null;
+    }
 
     if (name === 'width' || name === 'height') {
       return (scale && scale.type === 'ordinal' && !scale.points) ? (

--- a/src/js/components/mixins/SignalValue.jsx
+++ b/src/js/components/mixins/SignalValue.jsx
@@ -21,8 +21,12 @@ module.exports = {
 
   componentWillReceiveProps: function(nextProps) {
     var prevProps = this.props;
-    if (prevProps.signal) this.offSignal(prevProps.signal);
-    if (nextProps.signal) this.onSignal(nextProps.signal);
+    if (prevProps.signal) {
+      this.offSignal(prevProps.signal);
+    }
+    if (nextProps.signal) {
+      this.onSignal(nextProps.signal);
+    }
     if (nextProps.signal || nextProps.value !== prevProps.value) {
       this.setState({value: nextProps.signal ?
         model.signal(nextProps.signal) : nextProps.value});

--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -48,7 +48,9 @@ Scale.prototype.parent = null;
 // To prevent name collisions.
 function rename(name) {
   var count = 0;
-  while (names[name]) name += ++count;
+  while (names[name]) {
+    name += ++count;
+  }
   return (names[name] = 1, name);
 }
 

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -27,7 +27,8 @@ function value(name, val) {
   try {
     val = view.signal.apply(view, arguments);
     return set ? api : val;
-  } catch (e) {
+  }
+  catch (e) {
     return set ? (sg.init = val, api) : sg.init;
   }
 }


### PR DESCRIPTION
**Description of the problem this pull request fixes**

I'd written this patch last week and forgot to submit it; it rebased cleanly so here goes: this standardizes all conditional blocks to use curly braces, even for single-line `if` statements.

My recollection is that this rule was contentious, but my personal feeling is that the increased consistency (all blocks are curly'd) improves code scanning speed and reduces the risk for statements to escape the conditional block.

Changes proposed in this pull request:
- Use curly braces everywhere (`curly` rule in eslint)
- Always follow a closing brace with a newline (`brace-style` rule in eslint)

**Steps to functionally test this:**
- Smoke test to validate that no regressions were introduced
- `npm run lint | grep curly` to validate that no curly-brace inconsistencies are found
