### PR TITLE
Add initial tests for Group and Group.prototype.child

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
 ---
 extends:
   - "./eslint/eslint-defaults.yml"
+  - "./eslint/eslint-mocha.yml"

--- a/eslint/eslint-mocha.yml
+++ b/eslint/eslint-mocha.yml
@@ -1,0 +1,5 @@
+---
+# Globally permitting mocha constructs reduces the eslint configuration
+# needed within test files
+env:
+  mocha: true

--- a/karma.config.js
+++ b/karma.config.js
@@ -14,11 +14,13 @@ module.exports = function(config) {
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
       './node_modules/phantomjs-polyfill/bind-polyfill.js',
+      './src/**/*.test.js', // test files may be alongside source code
       './test/**/*.js' // specify files to watch for tests
     ],
     preprocessors: {
       // these files we want to be precompiled with webpack
       // also run tests through sourcemap for easier debugging
+      './src/**/*.test.js': ['webpack', 'sourcemap'],
       './test/**/*.js': ['webpack', 'sourcemap']
     },
     webpack: {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-addons-test-utils": "^0.14.6",
     "react-dom": "^0.14.3",
     "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0",
     "string.prototype.startswith": "^0.2.0",
     "vega": "^2.5.0",
     "vega-lite": "^1.0.1",

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -61,9 +61,6 @@ describe('Group Mark', function() {
 
     it('is a function', function() {
       expect(group).to.have.property('child');
-    });
-
-    it('is a function', function() {
       expect(group.child).to.be.a('function');
     });
 

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -1,7 +1,8 @@
-var chai = require('chai');
-chai.use(require('sinon-chai'));
-var expect = chai.expect;
-var sinon = require('sinon');
+/* eslint-env mocha */
+/* eslint no-unused-expressions:0 */
+'use strict';
+
+var expect = require('chai').expect;
 
 var Group = require('./Group');
 var Mark = require('./Mark');

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 /* eslint no-unused-expressions:0 */
 'use strict';
 

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -1,0 +1,104 @@
+var chai = require('chai');
+chai.use(require('sinon-chai'));
+var expect = chai.expect;
+var sinon = require('sinon');
+
+var Group = require('./Group');
+var Mark = require('./Mark');
+
+describe('Group Mark', function() {
+  var group;
+
+  beforeEach(function() {
+    group = new Group();
+  });
+
+  describe('constructor', function() {
+
+    it('is a constructor function', function() {
+      expect(Group).to.be.a('function');
+    });
+
+    it('may be used to create group instances', function() {
+      expect(group).to.be.an.instanceOf(Group);
+    });
+
+    it('inherits from Mark', function() {
+      expect(group).to.be.an.instanceOf(Mark);
+    });
+
+  });
+
+  describe('default properties', function() {
+
+    it('contains a properties object', function() {
+      expect(group).to.have.property('properties');
+    });
+
+    it('is initialized with a scales array', function() {
+      expect(group).to.have.property('scales');
+      expect(group.scales).to.deep.equal([]);
+    });
+
+    it('is initialized with a legends array', function() {
+      expect(group).to.have.property('legends');
+      expect(group.legends).to.deep.equal([]);
+    });
+
+    it('is initialized with a axes array', function() {
+      expect(group).to.have.property('axes');
+      expect(group.axes).to.deep.equal([]);
+    });
+
+    it('is initialized with a marks array', function() {
+      expect(group).to.have.property('marks');
+      expect(group.marks).to.deep.equal([]);
+    });
+
+  });
+
+  describe('child method', function() {
+
+    it('is a function', function() {
+      expect(group).to.have.property('child');
+    });
+
+    it('is a function', function() {
+      expect(group.child).to.be.a('function');
+    });
+
+    it('creates and returns child primitives within the group', function() {
+      [
+        'axes',
+        'legends',
+        'marks.group',
+        'marks.rect',
+        'marks.symbol'
+      ].forEach(function(primitiveType) {
+        var child = group.child(primitiveType);
+        expect(child).to.be.an('object');
+        expect(child.parent()).to.equal(group);
+      });
+    });
+
+    it('creates a scale but does not assign itself as parent', function() {
+      var scale = group.child('scales');
+      expect(scale.parent).to.be.null;
+    });
+
+    it('throws an error if provided an invalid type', function() {
+      expect(function() {
+        group.child('unsupported primitive');
+      }).to.throw;
+    });
+
+    it('can insert a pre-existing primitive into a group', function() {
+      var otherGroup = new Group();
+      expect(otherGroup.parent()).not.to.equal(group);
+      group.child('marks.group', otherGroup);
+      expect(otherGroup.parent()).to.equal(group);
+    });
+
+  });
+
+});


### PR DESCRIPTION
**Description of the problem this pull request fixes**

There were no tests for Group, and Group.child is instrumental to adding new marks. This PR begins to flesh out test coverage for the Group mark, starting with `Group.prototype.child`.
