### PR TITLE
eslint compliants for .test.js specs

### DIFF
--- a/src/js/model/primitives/Guide.test.js
+++ b/src/js/model/primitives/Guide.test.js
@@ -1,4 +1,5 @@
 /* eslint no-unused-expressions:0 */
+'use strict';
 var expect = require('chai').expect;
 
 var Guide = require('./Guide');

--- a/src/js/model/primitives/Primitive.test.js
+++ b/src/js/model/primitives/Primitive.test.js
@@ -1,10 +1,10 @@
 /* eslint no-unused-expressions:0 */
+'use strict';
 var expect = require('chai').expect;
 
 describe('Primitive', function() {
   var Primitive = require('./Primitive'),
       dl = require('datalib'),
-      model = require('../'),
       prim;
 
   describe('Export', function() {

--- a/src/js/model/primitives/Scale.test.js
+++ b/src/js/model/primitives/Scale.test.js
@@ -1,4 +1,8 @@
-var Scale = require('./Scale.js');
+/* eslint no-unused-expressions:0 */
+'use strict';
+var expect = require('chai').expect;
+
+var Scale = require('./Scale');
 var scaleA,
     scaleB,
     specA,


### PR DESCRIPTION
This PR addresses most eslint errors present in `*.test.js` mocha spec files.

The one remaining issue is the use of `undefined`, which is currently flagged as an error in eslint; I tend to prefer `typeof x === 'undefined'` when doing equality checks, but in this case `undefined` is actually standing in for a missing argument to a function so there's no comparably-obvious way to represent the usage than what's there already. For that reason I left it be until we could discuss.

To test, run `node_modules/.bin/eslint --ext .test.js src` to invoke eslint against just the .test.js spec files.
