### PR TITLE
Add an "eslint:branch" npm script to lint only changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx src",
+    "lint:branch": "eslint $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head lyra2) | grep '.js$') || true",
     "build": "npm run build:js && npm run build:scss",
     "build:js": "webpack -d",
     "build:scss": "node-sass --include-path src/scss src/scss/main.scss build/css/main.css",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .js,.jsx src",
-    "lint:branch": "eslint $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head lyra2) | grep '.js$') || true",
+    "lint:branch": "eslint $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head lyra2) | grep '.jsx*$') || true",
     "build": "npm run build:js && npm run build:scss",
     "build:js": "webpack -d",
     "build:scss": "node-sass --include-path src/scss src/scss/main.scss build/css/main.css",


### PR DESCRIPTION
This script is a stop-gap until we get to passing eslint (at which point we'd want to integrate eslint as a pre-task for `npm test`) -- it uses git's CLI to determine the commit at which the working branch diverged from our default `lyra2` branch, then runs only those files through eslint. I submit it as an easy way for us to check that we're conforming to our style rules before we PR a new branch, since going through the aggregated eslint output is a bit of a pain.
