### PR TITLE
getName wasn't returning the constructor name

### DIFF
--- a/src/js/components/Inspector.jsx
+++ b/src/js/components/Inspector.jsx
@@ -12,7 +12,7 @@ var Inspector = React.createClass({
     var props = this.props,
         primitive = lookup(props.id),
         from = lookup(primitive.from),
-        ctor = primitive.getName(),
+        ctor = primitive.constructor.name,
         InspectorType = Inspector[ctor],
         isMark = primitive instanceof Mark;
 

--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -58,12 +58,6 @@ Primitive.prototype.export = function(clean) {
   return _clean(dl.duplicate(this), clean);
 };
 
-
-Primitive.prototype.getName = function() {
-  return this.name || '';
-};
-
-
 /**
  * Exports the primitive as a complete Vega specification with extra definitions
  * to power Lyra-specific interaction (e.g., extra manipulator mark definitions).


### PR DESCRIPTION
The problem:
I made a getter for the wrong thing on the inspector.  It should have been getting the name of the constructor, not the name of the primitive.  This broke the inspector.  I'm a dope.
