### PR TITLE
Remove unused custom String prototype method

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,10 +5,6 @@ require('array.prototype.find');
 require('string.prototype.startswith');
 require('./transforms');
 
-String.prototype.capitalize = function() {
-  return this.charAt(0).toUpperCase() + this.slice(1);
-};
-
 // Initialize the Model.
 model = require('./model');
 model.init();


### PR DESCRIPTION
### Description of the problem this pull request fixes

`String.prototype.capitalize` is not being used anywhere in Lyra, and it is also not a standardized String method (and would therefore be a better candidate for a utility function than a String prototype method, were it to be needed after all).
### Steps to functionally test this:
- Unit tests
- Smoke test
