### PR TITLE
Knock out about half of the remaining eslint errors

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* eslint quote-props:0 */
+'use strict';
 var argv = require('yargs').argv;
 var path = require('path');
 
@@ -28,8 +31,8 @@ module.exports = function(config) {
     },
 
     webpack: {
-       devtool: 'inline-source-map',
-       resolve: {
+      devtool: 'inline-source-map',
+      resolve: {
         // allow us to avoid including extension name
         extensions: ['', '.js', '.jsx'],
 
@@ -111,7 +114,7 @@ module.exports = function(config) {
       // JSX parsing; but including it somehow fixes the coverage report bar
       // graph width rendering bug, so why not.
       instrumenters: {
-        'istanbul-react' : require('istanbul-react')
+        'istanbul-react': require('istanbul-react')
       },
       instrumenter: {
         '**/*.jsx': 'istanbul-react'

--- a/src/js/components/inspectors/ExtentProperty.jsx
+++ b/src/js/components/inspectors/ExtentProperty.jsx
@@ -43,11 +43,9 @@ var ExtentProperty = React.createClass({
       var name = x.name, prop = update[name];
       if (prop._disabled) {
         return;
-      }
-      else if (!start) {
+      } else if (!start) {
         start = name;
-      }
-      else if (start !== name) {
+      } else if (start !== name) {
         end = name;
       }
     });
@@ -103,7 +101,10 @@ var ExtentProperty = React.createClass({
 
           <div className="label">
             <select name="start" value={start} onChange={this.handleChange}>
-              {opts.filter(function(x) { return x.name !== end; })
+              {opts
+                .filter(function(x) {
+                  return x.name !== end;
+                })
                 .map(function(x) {
                   return (<option key={x.name} value={x.name}>{x.label}</option>);
                 })}
@@ -123,7 +124,9 @@ var ExtentProperty = React.createClass({
               (
                 <select name="end" value={end} onChange={this.handleChange}>
                   {opts
-                    .filter(function(x) { return x.name !== start && x.name !== center; })
+                    .filter(function(x) {
+                      return x.name !== start && x.name !== center;
+                    })
                     .map(function(x) {
                       return (<option key={x.name} value={x.name}>{x.label}</option>);
                     })}

--- a/src/js/components/inspectors/Property.jsx
+++ b/src/js/components/inspectors/Property.jsx
@@ -31,11 +31,9 @@ var Property = React.createClass({
           type = child && child.type;
       if (className === 'extra') {
         extraEl = child;
-      }
-      else if (className === 'control') {
+      } else if (className === 'control') {
         controlEl = child;
-      }
-      else if (type === 'label' || className === 'label') {
+      } else if (type === 'label' || className === 'label') {
         labelEl = child;
       }
     });

--- a/src/js/components/inspectors/SpatialPreset.jsx
+++ b/src/js/components/inspectors/SpatialPreset.jsx
@@ -21,8 +21,7 @@ var SpatialPreset = React.createClass({
     if (evt.target.checked) {
       update[name] = (name === 'width' || name === 'height') ?
         {scale: prop.scale, band: true} : {group: preset};
-    }
-    else {
+    } else {
       update[name] = {signal: propSg(primitive, name)};
     }
 
@@ -49,8 +48,7 @@ var SpatialPreset = React.createClass({
             onChange={this.handleChange} /> Automatic
         </label>
       ) : null;
-    }
-    else {
+    } else {
       return (
         <label>
           <input type="checkbox" name={name} checked={prop.group}

--- a/src/js/components/inspectors/SpatialPreset.jsx
+++ b/src/js/components/inspectors/SpatialPreset.jsx
@@ -19,10 +19,16 @@ var SpatialPreset = React.createClass({
         preset = name.indexOf('x') >= 0 ? 'width' : 'height';
 
     if (evt.target.checked) {
-      update[name] = (name === 'width' || name === 'height') ?
-        {scale: prop.scale, band: true} : {group: preset};
+      update[name] = (name === 'width' || name === 'height') ? {
+        scale: scale,
+        band: true
+      } : {
+        group: preset
+      };
     } else {
-      update[name] = {signal: propSg(primitive, name)};
+      update[name] = {
+        signal: propSg(primitive, name)
+      };
     }
 
     this.parse(primitive);
@@ -48,14 +54,14 @@ var SpatialPreset = React.createClass({
             onChange={this.handleChange} /> Automatic
         </label>
       ) : null;
-    } else {
-      return (
-        <label>
-          <input type="checkbox" name={name} checked={prop.group}
-            onChange={this.handleChange} /> Group {preset}
-        </label>
-      );
     }
+
+    return (
+      <label>
+        <input type="checkbox" name={name} checked={prop.group}
+          onChange={this.handleChange} /> Group {preset}
+      </label>
+    );
   }
 });
 

--- a/src/js/components/mixins/SignalValue.jsx
+++ b/src/js/components/mixins/SignalValue.jsx
@@ -64,8 +64,7 @@ module.exports = {
 
     if (signal) {
       model.signal(signal, value).update();
-    }
-    else {
+    } else {
       this._set(props.obj, value);
       this.setState({value: value});
     }

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -97,16 +97,14 @@ var DataTable = React.createClass({
         prim = model.primitive(sel.mark.def.lyra_id);
         prim.bind(cell.key, fullField._id);
       }
-    }
-    catch (e) {}
+    } catch (e) {}
 
     model.signal(sg.MODE, 'handles')
       .signal(sg.CELL, {});
 
     if (dropped) {
       this.parse(prim);
-    }
-    else {
+    } else {
       model.update();
     }
   },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,5 @@
-/* eslint strict: 0, no-undef: 0, no-unused-expressions: 0 */
+/* eslint no-unused-expressions: 0 */
+'use strict';
 
 // Additional requires to polyfill + browserify package.
 require('array.prototype.find');
@@ -6,11 +7,11 @@ require('string.prototype.startswith');
 require('./transforms');
 
 // Initialize the Model.
-model = require('./model');
+var model = require('./model');
 model.init();
 
 // Initialize components
-Sidebars = require('./components');
+var Sidebars = require('./components');
 
 var g = model.Scene.child('marks.group'),
     p = model.pipeline('cars'),
@@ -33,3 +34,7 @@ Promise.all([
 }).then(function() {
   Sidebars.forceUpdate();
 });
+
+// Expose model and Sidebars globally (via `window`)
+global.model = model;
+global.Sidebars = Sidebars;

--- a/src/js/model/primitives/Guide.js
+++ b/src/js/model/primitives/Guide.js
@@ -1,3 +1,4 @@
+'use strict';
 var inherits = require('inherits'),
     Primitive = require('./Primitive'),
     model = require('../'),

--- a/src/js/model/primitives/Guide.js
+++ b/src/js/model/primitives/Guide.js
@@ -42,8 +42,7 @@ function Guide(gtype, type, scale) {
       labels: {},
       axis: {}
     };
-  }
-  else if (gtype === GTYPES.LEGEND) {
+  } else if (gtype === GTYPES.LEGEND) {
     this._type = type;
     this[type] = +scale || scale._id;
     this.properties = {
@@ -73,8 +72,7 @@ Guide.prototype.export = Guide.prototype.manipulators = function(clean) {
 
   if (gtype === GTYPES.AXIS) {
     spec.scale = lookup(spec.scale).name;
-  }
-  else if (gtype === GTYPES.LEGEND) {
+  } else if (gtype === GTYPES.LEGEND) {
     spec[type] = lookup(spec[type]).name;
   }
 

--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     Primitive = require('./Primitive'),

--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -60,7 +60,9 @@ function rename(name) {
 //   {"data": ..., "field": ...} for a single field
 //   {"data": ..., "field": [...]} for multiple fields from the same dataset.
 //   {"fields": [...]} for multiple fields from distinct datasets.
-function fmap(f) { return f._name; }
+function fmap(f) {
+  return f._name;
+}
 
 function dataRef(ref) {
   var sets = {},
@@ -69,8 +71,7 @@ function dataRef(ref) {
   if (ref.length === 1 && (ref = ref[0])) {
     field = lookup(ref);
     return {data: field.parent().name, field: field._name};
-  }
-  else {
+  } else {
     for (i = 0, len = ref.length; i < len; ++i) {
       field = lookup(ref[i]);
       data = field.parent();
@@ -84,8 +85,7 @@ function dataRef(ref) {
         data: data.name,
         field: sets[data._id].map(fmap)
       };
-    }
-    else {
+    } else {
       ref = {fields: []};
       for (i = 0, len = keys.length; i < len; ++i) {
         data = lookup(keys[i]);

--- a/src/js/model/primitives/data/Dataset.js
+++ b/src/js/model/primitives/data/Dataset.js
@@ -56,7 +56,7 @@ Dataset.prototype.init = function(opt) {
 /**
  * Gets the dataset's input tuples (i.e., prior to any transformations being
  * applied).
- * @return {Object[]} An array of objects.
+ * @returns {Object[]} An array of objects.
  */
 Dataset.prototype.input = function() {
   return this._values || this._vals;
@@ -66,7 +66,7 @@ Dataset.prototype.input = function() {
  * Gets the dataset's output tuples (i.e., after all transformations have been
  * applied). This requires a visualization to have been parsed. If no
  * visualization has been parsed, returns the input tuples.
- * @return {Object[]} An array of objects.
+ * @returns {Object[]} An array of objects.
  */
 Dataset.prototype.output = function() {
   var view = require('../../').view;
@@ -76,7 +76,7 @@ Dataset.prototype.output = function() {
 /**
  * Gets the schema of the Dataset -- an object where the keys correspond to the
  * names of the dataset's fields, and the values are {@link Field|Field Primitives}.
- * @return {Object} The Dataset's schema.
+ * @returns {Object} The Dataset's schema.
  */
 Dataset.prototype.schema = function() {
   if (this._schema) {
@@ -97,7 +97,7 @@ Dataset.prototype.schema = function() {
  * Calculates a profile of summary statistics of every field in the Dataset.
  * @see  {@link https://github.com/vega/datalib/wiki/Statistics#dl_summary|datalib's}
  * documentation for more information.
- * @return {Object} The Dataset's summary profile.
+ * @returns {Object} The Dataset's summary profile.
  */
 Dataset.prototype.summary = function() {
   var s = this.schema();

--- a/src/js/model/primitives/data/Dataset.js
+++ b/src/js/model/primitives/data/Dataset.js
@@ -34,16 +34,13 @@ Dataset.prototype.init = function(opt) {
   return new Promise(function(resolve, reject) {
     if (dl.isString(opt)) {
       resolve((self.source = opt, self));
-    }
-    else if (dl.isArray(opt)) {
+    } else if (dl.isArray(opt)) {
       resolve((self._values = opt, self));
-    }
-    else {  // opt is an object
+    } else {  // opt is an object
       self.format = opt.format;
       if (opt.values) {
         resolve((self._values = dl.read(opt.values, self.format), self));
-      }
-      else if (opt.url) {
+      } else if (opt.url) {
         resolve(promisify(dl.load)({url: (self.url = opt.url)})
           .then(function(data) {
             self._vals = dl.read(data, self.format);
@@ -51,7 +48,9 @@ Dataset.prototype.init = function(opt) {
           }));
       }
     }
-  }).then(function(self) { return self.schema(); });
+  }).then(function(self) {
+    return self.schema();
+  });
 };
 
 /**
@@ -103,16 +102,19 @@ Dataset.prototype.schema = function() {
 Dataset.prototype.summary = function() {
   var s = this.schema();
   return dl.summary(this.output())
-    .filter(function(p) { return p.field !== '_id'; })
-    .map(function(p) { return (s[p.field].profile(p), p); });
+    .filter(function(p) {
+      return p.field !== '_id';
+    })
+    .map(function(p) {
+      return (s[p.field].profile(p), p);
+    });
 };
 
 Dataset.prototype.export = function(resolve) {
   var spec = Primitive.prototype.export.call(this, resolve);
   if (this._values) {
     spec.values = this._values;
-  }
-  else if (this._vals && !resolve) {
+  } else if (this._vals && !resolve) {
     spec.values = this._vals;
     delete spec.url;
   }

--- a/src/js/model/primitives/data/Dataset.js
+++ b/src/js/model/primitives/data/Dataset.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     promisify = require('es6-promisify'),

--- a/src/js/model/primitives/data/Field.js
+++ b/src/js/model/primitives/data/Field.js
@@ -44,7 +44,7 @@ inherits(Field, Primitive);
 /**
  * Gets/sets the Field's statistical profile. If one does not exist, calls
  * its {@link Dataset#summary|Dataset's profiler} first.
- * @return {Object} The Field's summary profile.
+ * @returns {Object} The Field's summary profile.
  */
 Field.prototype.profile = function(p) {
   if (p !== undefined) {

--- a/src/js/model/primitives/data/Field.js
+++ b/src/js/model/primitives/data/Field.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     vl = require('vega-lite'),
     inherits = require('inherits'),

--- a/src/js/model/primitives/data/Field.js
+++ b/src/js/model/primitives/data/Field.js
@@ -49,13 +49,11 @@ inherits(Field, Primitive);
 Field.prototype.profile = function(p) {
   if (p !== undefined) {
     return (this._profile = p, this);
-  }
-  else if (this._profile) {
+  } else if (this._profile) {
     return this._profile;
   }
-  else {
-    return (this.parent().summary(), this._profile);
-  }
+
+  return (this.parent().summary(), this._profile);
 };
 
 module.exports = Field;

--- a/src/js/model/primitives/data/Pipeline.js
+++ b/src/js/model/primitives/data/Pipeline.js
@@ -1,3 +1,4 @@
+'use strict';
 var inherits = require('inherits'),
     Primitive = require('../Primitive'),
     Dataset = require('./Dataset');

--- a/src/js/model/primitives/data/Pipeline.js
+++ b/src/js/model/primitives/data/Pipeline.js
@@ -33,7 +33,7 @@ Pipeline.prototype.parent = null;
  * Exports each of the constituent {@link Dataset|Datasets}.
  * @param  {boolean} [clean=true] - Should Lyra-specific properties be removed
  * or resolved (e.g., converting property signal references to actual values).
- * @return {Object[]} An array of Vega data source specifications.
+ * @returns {Object[]} An array of Vega data source specifications.
  */
 Pipeline.prototype.export = function(clean) {
   return [this._source.export(clean)]

--- a/src/js/model/primitives/data/Pipeline.js
+++ b/src/js/model/primitives/data/Pipeline.js
@@ -37,7 +37,9 @@ Pipeline.prototype.parent = null;
  */
 Pipeline.prototype.export = function(clean) {
   return [this._source.export(clean)]
-    .concat(this._aggregates.map(function(a) { return a.export(clean); }));
+    .concat(this._aggregates.map(function(a) {
+      return a.export(clean);
+    }));
 };
 
 module.exports = Pipeline;

--- a/src/js/model/primitives/marks/Area.js
+++ b/src/js/model/primitives/marks/Area.js
@@ -105,7 +105,7 @@ Area.prototype.export = function(resolve) {
       field: 'y'
     };
   }
-  if (spec.properties.update.orient.value == 'horizontal') {
+  if (spec.properties.update.orient.value === 'horizontal') {
     delete spec.properties.update.y2;
   } else {
     delete spec.properties.update.x2;

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     sg = require('../../signals'),

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -57,7 +57,7 @@ inherits(Mark, Primitive);
  * properties with literal values to Lyra-specific signals. Each mark subclass
  * will register the necessary streams to change the signal values
  * (e.g., `initHandlers`).
- * @return {Object} The Mark.
+ * @returns {Object} The Mark.
  */
 Mark.prototype.init = function() {
   var props = this.properties,
@@ -82,7 +82,7 @@ Mark.prototype.init = function() {
  * @todo  Rename to `from`? A mark can be backed by another mark when connected.
  * @param  {number} [id] - The ID of a Dataset or Pipeline Primitive. If
  * Pipeline, then the source Dataset is used.
- * @return {Object} If no ID is specified, the backing Dataset primitive if any.
+ * @returns {Object} If no ID is specified, the backing Dataset primitive if any.
  * If an ID is specified, the Mark is returned.
  */
 Mark.prototype.dataset = function(id) {
@@ -97,17 +97,17 @@ Mark.prototype.dataset = function(id) {
     // TODO
     this.from = from._source._id;
     return this;
-  } else {
-    this.from = undefined;
-    return this;
   }
+
+  this.from = undefined;
+  return this;
 };
 
 /**
  * Initializes the interaction logic for the mark's handle manipulators. This
  * involves setting {@link https://github.com/vega/vega/wiki/Signals|the streams}
  * of the mark's property signals.
- * @return {Object} The Mark.
+ * @returns {Object} The Mark.
  */
 Mark.prototype.initHandles = function() {};
 

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -90,17 +90,14 @@ Mark.prototype.dataset = function(id) {
   if (!arguments.length) {
     from = lookup(this.from);
     return from && lookup(from.parent()._id);
-  }
-  else if ((from = lookup(id)) instanceof Dataset) {
+  } else if ((from = lookup(id)) instanceof Dataset) {
     this.from = id;
     return this;
-  }
-  else if (from instanceof Pipeline) {
+  } else if (from instanceof Pipeline) {
     // TODO
     this.from = from._source._id;
     return this;
-  }
-  else {
+  } else {
     this.from = undefined;
     return this;
   }
@@ -133,7 +130,7 @@ Mark.prototype.export = function(clean) {
       update[k] = {value: v};
     }
 
-    if (v.scale){
+    if (v.scale) {
       v.scale = (s = lookup(v.scale)) && s.name;
     }
     if (v.field) {

--- a/src/js/model/primitives/marks/Rect.js
+++ b/src/js/model/primitives/marks/Rect.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     sg = require('../../../model/signals'),

--- a/src/js/model/primitives/marks/Rect.js
+++ b/src/js/model/primitives/marks/Rect.js
@@ -28,7 +28,7 @@ function Rect() {
     y2: {value: 60},
     xc: {value: 60, _disabled: true},
     yc: {value: 60, _disabled: true},
-    width:  {value: 30, _disabled: true},
+    width: {value: 30, _disabled: true},
     height: {value: 30, _disabled: true}
   });
 

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -1,3 +1,4 @@
+'use strict';
 var inherits = require('inherits'),
     sg = require('../../signals'),
     Group = require('./Group');

--- a/src/js/model/primitives/marks/Symbol.js
+++ b/src/js/model/primitives/marks/Symbol.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     sg = require('../../../model/signals'),

--- a/src/js/model/primitives/marks/manipulators.js
+++ b/src/js/model/primitives/marks/manipulators.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     sg = require('../../signals'),
     ns = require('../../../util/ns');

--- a/src/js/model/rules/data.js
+++ b/src/js/model/rules/data.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = function(parsed, from) {
   var map = this._rule._map.data;
   map.source = from.parent()._source._id;

--- a/src/js/model/rules/guides.js
+++ b/src/js/model/rules/guides.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     Guide = require('../primitives/Guide'),
     model = require('../'),

--- a/src/js/model/rules/index.js
+++ b/src/js/model/rules/index.js
@@ -51,19 +51,18 @@ function rules(prototype) {
 function channel(name) {
   if (vl.channel.CHANNELS.indexOf(name) >= 0) {
     return name;
-  } else {
-    switch (name) {
-      case 'x+':
-      case 'x2':
-      case 'width':
-        return 'x';
-      case 'y+':
-      case 'y2':
-      case 'height':
-        return 'y';
-      case 'fill':
-        return 'color';
-    }
+  }
+  switch (name) {
+    case 'x+':
+    case 'x2':
+    case 'width':
+      return 'x';
+    case 'y+':
+    case 'y2':
+    case 'height':
+      return 'y';
+    case 'fill':
+      return 'color';
   }
 }
 

--- a/src/js/model/rules/index.js
+++ b/src/js/model/rules/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     vg = require('vega'),
     vl = require('vega-lite'),

--- a/src/js/model/rules/index.js
+++ b/src/js/model/rules/index.js
@@ -51,8 +51,7 @@ function rules(prototype) {
 function channel(name) {
   if (vl.channel.CHANNELS.indexOf(name) >= 0) {
     return name;
-  }
-  else {
+  } else {
     switch (name) {
       case 'x+':
       case 'x2':
@@ -82,8 +81,7 @@ function fieldRef(field) {
   if (agg) {
     res = re.agg.exec(name);
     ref.aggregate = res[1];
-  }
-  else if (bin) {
+  } else if (bin) {
     res = re.bin.exec(name);
     ref.bin = true;
   }

--- a/src/js/model/rules/marks.js
+++ b/src/js/model/rules/marks.js
@@ -1,3 +1,4 @@
+'use strict';
 var model = require('../'),
     propSg = require('../../util/prop-signal'),
     lookup = model.primitive;

--- a/src/js/model/rules/marks.js
+++ b/src/js/model/rules/marks.js
@@ -3,47 +3,28 @@ var model = require('../'),
     propSg = require('../../util/prop-signal'),
     lookup = model.primitive;
 
-module.exports = function(parsed, property, channel) {
-  var map = this._rule._map,
-      def = parsed.spec.marks[0].marks[0],
-      props = this.properties.update,
-      dprops = def.properties.update,
-      from;
-
-  if (def.from && def.from.data) {
-    this.dataset(map.data[def.from.data]);
-    from = lookup(this.from);
-  }
-
-  if (this.type === 'rect' && (channel === 'x' || channel === 'y')) {
-    rectSpatial.call(this, map, property, channel, props, dprops, from);
-  } else {
-    bindProperty.call(this, map, property, props, dprops, from);
-  }
-};
-
 function bindProperty(map, property, props, def, from) {
   var d = def[property],
       p = (props[property] = {});
 
-  if (d.scale !== undefined) {
+  if (typeof d.scale !== 'undefined') {
     p.scale = map.scales[d.scale];
   }
-  if (d.field !== undefined) {
+  if (typeof d.field !== 'undefined') {
     if (d.field.group) {
       p.group = d.field.group;
     } else {
       p.field = from.schema()[d.field]._id;
     }
   }
-  if (d.value !== undefined) {
+  if (typeof d.value !== 'undefined') {
     model.signal(p.signal = propSg(this, property), d.value);
   }
 
-  if (d.band !== undefined) {
+  if (typeof d.band !== 'undefined') {
     p.band = d.band;
   }
-  if (d.offset !== undefined) {
+  if (typeof d.offset !== 'undefined') {
     p.offset = d.offset;
   }
 }
@@ -80,3 +61,22 @@ function rectSpatial(map, property, channel, props, def, from) {
     props[bind]._disabled = true;
   }
 }
+
+module.exports = function(parsed, property, channel) {
+  var map = this._rule._map,
+      def = parsed.spec.marks[0].marks[0],
+      props = this.properties.update,
+      dprops = def.properties.update,
+      from;
+
+  if (def.from && def.from.data) {
+    this.dataset(map.data[def.from.data]);
+    from = lookup(this.from);
+  }
+
+  if (this.type === 'rect' && (channel === 'x' || channel === 'y')) {
+    rectSpatial.call(this, map, property, channel, props, dprops, from);
+  } else {
+    bindProperty.call(this, map, property, props, dprops, from);
+  }
+};

--- a/src/js/model/rules/marks.js
+++ b/src/js/model/rules/marks.js
@@ -17,8 +17,7 @@ module.exports = function(parsed, property, channel) {
 
   if (this.type === 'rect' && (channel === 'x' || channel === 'y')) {
     rectSpatial.call(this, map, property, channel, props, dprops, from);
-  }
-  else {
+  } else {
     bindProperty.call(this, map, property, props, dprops, from);
   }
 };
@@ -33,8 +32,7 @@ function bindProperty(map, property, props, def, from) {
   if (d.field !== undefined) {
     if (d.field.group) {
       p.group = d.field.group;
-    }
-    else {
+    } else {
       p.field = from.schema()[d.field]._id;
     }
   }
@@ -71,8 +69,7 @@ function rectSpatial(map, property, channel, props, def, from) {
     bindProperty.call(this, map, channel, props, def, from);
     bindProperty.call(this, map, bind, props, def, from);
     props[span]._disabled = true;
-  }
-  else {
+  } else {
     def[channel] = def[cntr]; // Map xc/yc => x/y for binding.
     bindProperty.call(this, map, channel, props, def, from);
 

--- a/src/js/model/rules/scales.js
+++ b/src/js/model/rules/scales.js
@@ -11,7 +11,9 @@ module.exports = function(parsed) {
   var map = this._rule._map.scales,
       channels = dl.keys(parsed.rule.encoding),
       scales = parsed.spec.marks[0].scales,
-      find = function(x) { return x.name === name; },
+      find = function(x) {
+        return x.name === name;
+      },
       i = 0, len = channels.length,
       name, def, curr;
 
@@ -48,8 +50,7 @@ function parse(def) {
   // TODO: Use bandSize initially?
   if (def.name === 'x' || range === rules.CELLW || dl.equal(range, REF_CELLW)) {
     def.range = 'width';
-  }
-  else if (def.name === 'y' || range === rules.CELLH || dl.equal(range, REF_CELLH)) {
+  } else if (def.name === 'y' || range === rules.CELLH || dl.equal(range, REF_CELLH)) {
     def.range = 'height';
   }
 

--- a/src/js/model/signals/defaults.js
+++ b/src/js/model/signals/defaults.js
@@ -75,8 +75,8 @@ signals[MOUSE] = {
 signals[CURSOR] = {
   name: CURSOR,
   streams: [
-    {'type': 'mousedown', 'expr': "eventItem() && eventItem().cursor || 'default'"},
-    {'type': 'mouseup', 'expr': "'default'"}
+    {type: 'mousedown', expr: "eventItem() && eventItem().cursor || 'default'"},
+    {type: 'mouseup', expr: "'default'"}
   ]
 };
 
@@ -86,8 +86,8 @@ module.exports = {
   SELECTED: SELECTED,
   MODE: MODE,
   ANCHOR: ANCHOR,
-  DELTA:  DELTA,
+  DELTA: DELTA,
   CURSOR: CURSOR,
-  CELL:  CELL,
+  CELL: CELL,
   MOUSE: MOUSE
 };

--- a/src/js/model/signals/defaults.js
+++ b/src/js/model/signals/defaults.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     ns = require('../../util/ns'),
     signals = {};

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     ns = require('../../util/ns'),
     signals, defaults;

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -3,6 +3,14 @@ var dl = require('datalib'),
     ns = require('../../util/ns'),
     signals, defaults;
 
+var api = module.exports = function() {
+  return signals;
+};
+
+function ref(name) {
+  return {signal: ns(name)};
+}
+
 function init(name, val) {
   signals[name = ns(name)] = {
     name: name,
@@ -10,10 +18,6 @@ function init(name, val) {
     _idx: dl.keys(signals).length
   };
   return ref(name);
-}
-
-function ref(name) {
-  return {signal: ns(name)};
 }
 
 function value(name, val) {
@@ -61,9 +65,6 @@ function streams(name, def) {
   return (sg.streams = def, api);
 }
 
-var api = module.exports = function() {
-  return signals;
-};
 api.init = init;
 api.ref = ref;
 api.value = value;

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -27,8 +27,7 @@ function value(name, val) {
   try {
     val = view.signal.apply(view, arguments);
     return set ? api : val;
-  }
-  catch (e) {
+  } catch (e) {
     return set ? (sg.init = val, api) : sg.init;
   }
 }
@@ -46,8 +45,9 @@ function stash() {
     if (defaults.names.indexOf(k) >= 0) {
       continue;
     }
-    try { signals[k].init = view.signal(k); }
-    catch (e) {}
+    try {
+      signals[k].init = view.signal(k);
+    } catch (e) {}
   }
 
   return signals;
@@ -61,7 +61,9 @@ function streams(name, def) {
   return (sg.streams = def, api);
 }
 
-var api = module.exports = function() { return signals; };
+var api = module.exports = function() {
+  return signals;
+};
 api.init = init;
 api.ref = ref;
 api.value = value;

--- a/src/js/transforms/BubbleCursor.js
+++ b/src/js/transforms/BubbleCursor.js
@@ -46,7 +46,7 @@ inherits(BubbleCursor, Transform);
  * The transform method is automatically called by Vega whenever the bubble
  * cursor region needs to be recalculated (e.g., when the user moves the mouse).
  * @param {Object} input - A Vega-Dataflow ChangeSet.
- * @return {Object} output - A Vega-Dataflow ChangeSet.
+ * @returns {Object} output - A Vega-Dataflow ChangeSet.
  */
 BubbleCursor.prototype.transform = function(input) {
   var g = this._graph,

--- a/src/js/transforms/BubbleCursor.js
+++ b/src/js/transforms/BubbleCursor.js
@@ -77,8 +77,7 @@ BubbleCursor.prototype.transform = function(input) {
   if (cache.length && (mouseCache.x !== mouse.x || mouseCache.y !== mouse.y)) {
     output.mod.push(dl.extend(start, mouse));
     output.mod.push(dl.extend(end, mouse));
-  }
-  else if (!cache.length) {
+  } else if (!cache.length) {
     cache.push(dl.extend(start, mouse));
 
     for (; item; item = item.mark && item.mark.group) {
@@ -94,8 +93,7 @@ BubbleCursor.prototype.transform = function(input) {
         d.y += offset.y;
         return d;
       }));
-    }
-    else {
+    } else {
       cache.push.apply(cache, cousins.reduce(function(acc, i) {
         var b = i.bounds || i.mark.bounds;
         return acc.concat([

--- a/src/js/transforms/BubbleCursor.js
+++ b/src/js/transforms/BubbleCursor.js
@@ -1,3 +1,4 @@
+'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
     vg = require('vega'),


### PR DESCRIPTION
### Description of the problem this pull request fixes

This PR reduces the noise of running `npm run lint` or `lint:branch` by cleaning up several broad categories of lint errors: JSDoc return statements, curly brace usage and block indentation, no need to use an `else` if all prior branches have `return`'d, etc.

It also makes the exposure of `model` and `Sidebar` in the global scope an explicit action.
### Steps to functionally test this:
- `npm test`
- `npm run lint` should return ~86 issues, rather than over 175 in lyra2 branch
- Smoke
