### PR TITLE
WIP: redux boilerplate set up

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.6",
     "react-dom": "^0.14.3",
+    "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-devtools": "^3.1.1",
     "sinon": "^1.17.2",
@@ -97,7 +98,6 @@
     "start": "webpack-dev-server --devtool=cheap-module-source-map --inline"
   },
   "dependencies": {
-    "jsdoc": "^3.4.0",
-    "react-redux": "^4.4.1"
+    "jsdoc": "^3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-devtools": "^3.1.1",
+    "redux-immutable": "^3.0.6",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
     "string.prototype.startswith": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "vega-lite": "^1.0.1",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1",
-    "webpack-hot-middleware": "^2.10.0",
     "yargs": "^4.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "vega-lite": "^1.0.1",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1",
+    "webpack-hot-middleware": "^2.10.0",
     "yargs": "^4.2.0"
   },
   "scripts": {
@@ -97,6 +98,7 @@
     "start": "webpack-dev-server --devtool=cheap-module-source-map --inline"
   },
   "dependencies": {
-    "jsdoc": "^3.4.0"
+    "jsdoc": "^3.4.0",
+    "react-redux": "^4.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mocha": "^2.4.5",
     "node-sass": "^3.4.2",
     "nodemon": "^1.8.1",
+    "object-assign": "^4.0.1",
     "phantomjs": "^1.9.19",
     "phantomjs-polyfill": "0.0.1",
     "react": "^0.14.3",

--- a/src/js/actions/sampleActions.js
+++ b/src/js/actions/sampleActions.js
@@ -1,0 +1,10 @@
+'use strict';
+var types = require('../constants/sampleTypes');
+
+module.exports.addTodo = function addTodo(text) {
+  return {
+    type: types.ADD_TODO,
+    text: text
+  };
+};
+

--- a/src/js/components/index.jsx
+++ b/src/js/components/index.jsx
@@ -5,7 +5,7 @@ var ReactDOM = require('react-dom'),
     Provider = require('react-redux').Provider,
     configureStore = require('../store/configureStore');
 
-var store = configureStore();
+var store = configureStore;
 
 module.exports = ReactDOM.render(
   <Provider store={store}>

--- a/src/js/components/index.jsx
+++ b/src/js/components/index.jsx
@@ -1,9 +1,15 @@
 'use strict';
 var ReactDOM = require('react-dom'),
     Sidebars = require('./Sidebars'),
-    React = require('react');
+    React = require('react'),
+    Provider = require('react-redux').Provider,
+    configureStore = require('../store/configureStore');
+
+var store = configureStore();
 
 module.exports = ReactDOM.render(
-  <Sidebars />,
+  <Provider store={store}>
+    <Sidebars />
+  </Provider>,
   d3.select('#sidebars').node()
 );

--- a/src/js/constants/sampleTypes.js
+++ b/src/js/constants/sampleTypes.js
@@ -1,0 +1,7 @@
+'use strict';
+module.exports.ADD_TODO = 'ADD_TODO';
+module.exports.DELETE_TODO = 'DELETE_TODO';
+module.exports.EDIT_TODO = 'EDIT_TODO';
+module.exports.MARK_TODO = 'MARK_TODO';
+module.exports.MARK_ALL = 'MARK_ALL';
+module.exports.CLEAR_MARKED = 'CLEAR_MARKED';

--- a/src/js/reducers/example.js
+++ b/src/js/reducers/example.js
@@ -1,4 +1,8 @@
+// THIS IS AN EXAMPLE
+// NOT USED FOR REAL IN THE APPLICATION
+
 'use strict';
+var assign = require('object-assign');
 
 var types = {
   ADD_TODO: 'ADD_TODO',
@@ -10,55 +14,45 @@ var types = {
 };
 
 function todos(state, action) {
-  if (!state){
-    state = {};
-  }
+  state = state || initialState
   switch (action.type) {
-    case types.ADD_TODO:
-      return [
-        {
-          id: state.reduce(function (maxId, todo) { Math.max(todo.id, maxId), -1}) + 1,
-          completed: false,
-          text: action.text
-        },
-        ...state
-      ]
+  case types.ADD_TODO:
+    return [{
+      id: (state.length === 0) ? 0 : state[0].id + 1,
+      marked: false,
+      text: action.text
+    }].concat(state);
 
-    case types.DELETE_TODO:
-      return state.filter(function(todo) {
-        todo.id !== action.id
-      })
+  case types.DELETE_TODO:
+    return state.filter(function(todo) {
+      return todo.id !== action.id
+    });
 
-    case types.EDIT_TODO:
-      return state.map(function(todo) {
-        todo.id === action.id ?
-          Object.assign({}, todo, { text: action.text }) :
-          todo
-      })
+  case types.EDIT_TODO:
+    return state.map(function(todo) {
+      return todo.id === action.id ?
+        assign({}, todo, { text: action.text }) :
+        todo
+    });
 
-    case types.COMPLETE_TODO:
-      return state.map(function(todo) {
-        todo.id === action.id ?
-          Object.assign({}, todo, { completed: !todo.completed }) :
-          todo
-      })
+  case types.MARK_TODO:
+    return state.map(function(todo) {
+      return todo.id === action.id ?
+        assign({}, todo, { marked: !todo.marked }) :
+        todo
+    });
 
-    case types.COMPLETE_ALL:
-      var areAllMarked = state.every(function(todo) {
-        todo.completed
-      });
+  case types.MARK_ALL:
+    var areAllMarked = state.every(function(todo) { return todo.marked });
+    return state.map(function(todo) {
+      return assign({}, todo, { marked: !areAllMarked })
+    });
 
-      return state.map(function(todo) {
-        Object.assign({}, todo, {
-          completed: !areAllMarked
-        })
-      })
+  case types.CLEAR_MARKED:
+    return state.filter(function(todo) { return todo.marked === false });
 
-    case types.CLEAR_COMPLETED:
-      return state.filter(function(todo) {todo.completed === false})
-
-    default:
-      return state
+  default:
+    return state;
   }
 }
 

--- a/src/js/reducers/example.js
+++ b/src/js/reducers/example.js
@@ -1,0 +1,62 @@
+var types = {
+  ADD_TODO: 'ADD_TODO',
+  DELETE_TODO: 'DELETE_TODO',
+  EDIT_TODO: 'EDIT_TODO',
+  COMPLETE_TODO: 'COMPLETE_TODO',
+  COMPLETE_ALL: 'COMPLETE_ALL',
+  CLEAR_COMPLETED: 'CLEAR_COMPLETED'
+};
+
+
+module.exports = function todos(state, action) {
+  if (!state){
+    state = {};
+  }
+  switch (action.type) {
+    case types.ADD_TODO:
+      return [
+        {
+          id: state.reduce(function (maxId, todo) { Math.max(todo.id, maxId), -1}) + 1,
+          completed: false,
+          text: action.text
+        },
+        ...state
+      ]
+
+    case types.DELETE_TODO:
+      return state.filter(function(todo) {
+        todo.id !== action.id
+      })
+
+    case types.EDIT_TODO:
+      return state.map(function(todo) {
+        todo.id === action.id ?
+          Object.assign({}, todo, { text: action.text }) :
+          todo
+      })
+
+    case types.COMPLETE_TODO:
+      return state.map(function(todo) {
+        todo.id === action.id ?
+          Object.assign({}, todo, { completed: !todo.completed }) :
+          todo
+      })
+
+    case types.COMPLETE_ALL:
+      var areAllMarked = state.every(function(todo) {
+        todo.completed
+      });
+
+      return state.map(function(todo) {
+        Object.assign({}, todo, {
+          completed: !areAllMarked
+        })
+      })
+
+    case types.CLEAR_COMPLETED:
+      return state.filter(function(todo) {todo.completed === false})
+
+    default:
+      return state
+  }
+}

--- a/src/js/reducers/example.js
+++ b/src/js/reducers/example.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var types = {
   ADD_TODO: 'ADD_TODO',
   DELETE_TODO: 'DELETE_TODO',
@@ -7,8 +9,7 @@ var types = {
   CLEAR_COMPLETED: 'CLEAR_COMPLETED'
 };
 
-
-module.exports = function todos(state, action) {
+function todos(state, action) {
   if (!state){
     state = {};
   }
@@ -60,3 +61,5 @@ module.exports = function todos(state, action) {
       return state
   }
 }
+
+module.exports = todos;

--- a/src/js/reducers/example.js
+++ b/src/js/reducers/example.js
@@ -1,58 +1,31 @@
 // THIS IS AN EXAMPLE
 // NOT USED FOR REAL IN THE APPLICATION
-
+/* eslint new-cap:0 */
 'use strict';
-var assign = require('object-assign');
+var types = require('../constants/sampleTypes');
+var Immutable = require('immutable');
 
-var types = {
-  ADD_TODO: 'ADD_TODO',
-  DELETE_TODO: 'DELETE_TODO',
-  EDIT_TODO: 'EDIT_TODO',
-  COMPLETE_TODO: 'COMPLETE_TODO',
-  COMPLETE_ALL: 'COMPLETE_ALL',
-  CLEAR_COMPLETED: 'CLEAR_COMPLETED'
-};
+var initialState = Immutable.List([
+    {
+      text: 'Use Redux',
+      completed: false,
+      id: 0
+    }
+]);
 
 function todos(state, action) {
-  state = state || initialState
+  state = state || initialState;
   switch (action.type) {
-  case types.ADD_TODO:
-    return [{
-      id: (state.length === 0) ? 0 : state[0].id + 1,
-      marked: false,
-      text: action.text
-    }].concat(state);
-
-  case types.DELETE_TODO:
-    return state.filter(function(todo) {
-      return todo.id !== action.id
-    });
-
-  case types.EDIT_TODO:
-    return state.map(function(todo) {
-      return todo.id === action.id ?
-        assign({}, todo, { text: action.text }) :
-        todo
-    });
-
-  case types.MARK_TODO:
-    return state.map(function(todo) {
-      return todo.id === action.id ?
-        assign({}, todo, { marked: !todo.marked }) :
-        todo
-    });
-
-  case types.MARK_ALL:
-    var areAllMarked = state.every(function(todo) { return todo.marked });
-    return state.map(function(todo) {
-      return assign({}, todo, { marked: !areAllMarked })
-    });
-
-  case types.CLEAR_MARKED:
-    return state.filter(function(todo) { return todo.marked === false });
-
-  default:
-    return state;
+    case types.ADD_TODO:
+      var item = Immutable.List[{
+        id: (state.length === 0) ? 0 : state[0].id + 1,
+        marked: false,
+        text: action.text
+      }];
+      // this will return an immutable
+      return state.merge(item);
+    default:
+      return state;
   }
 }
 

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,4 +1,5 @@
-var combineReducers = require('redux').combineReducers;
+'use strict';
+var combineReducers = require('redux-immutable').combineReducers;
 var example = require('./example');
 
 module.exports = combineReducers({

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,0 +1,8 @@
+var combineReducers = require('redux').combineReducers;
+var example = require('./example');
+
+var combineAppReducers = combineReducers({
+  example
+});
+
+module.exports = combineAppReducers;

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,8 +1,6 @@
 var combineReducers = require('redux').combineReducers;
 var example = require('./example');
 
-var combineAppReducers = combineReducers({
-  example
+module.exports = combineReducers({
+  example: example
 });
-
-module.exports = combineAppReducers;

--- a/src/js/store/configureStore.js
+++ b/src/js/store/configureStore.js
@@ -1,0 +1,16 @@
+var createStore  = require('redux').createStore;
+var rootReducer = require('../reducers');
+
+var configureStore = function(initialState) {
+  var store = createStore(rootReducer, initialState);
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', () => {
+      var nextReducer = require('../reducers').default;
+      store.replaceReducer(nextReducer)
+    })
+  }
+  return store;
+}
+
+module.exports = configureStore;

--- a/src/js/store/configureStore.js
+++ b/src/js/store/configureStore.js
@@ -3,13 +3,6 @@ var rootReducer = require('../reducers');
 
 var configureStore = function(initialState) {
   var store = createStore(rootReducer, initialState);
-  if (module.hot) {
-    // Enable Webpack hot module replacement for reducers
-    module.hot.accept('../reducers', () => {
-      var nextReducer = require('../reducers').default;
-      store.replaceReducer(nextReducer)
-    })
-  }
   return store;
 }
 

--- a/src/js/store/configureStore.js
+++ b/src/js/store/configureStore.js
@@ -1,9 +1,11 @@
-var createStore  = require('redux').createStore;
+/* eslint new-cap:0 */
+'use strict';
+var createStore = require('redux').createStore;
+var Immutable = require('immutable');
+
+// reducer/index.js returns combinedReducers();
 var rootReducer = require('../reducers');
 
-var configureStore = function(initialState) {
-  var store = createStore(rootReducer, initialState);
-  return store;
-}
-
-module.exports = configureStore;
+// Create immutable state
+var initialState = Immutable.Map();
+module.exports = createStore(rootReducer, initialState);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ module.exports = {
     extensions: [ '', '.js', '.jsx' ]
   },
   plugins: [
+    new webpack.HotModuleReplacementPlugin(),
     // Extract the "vendor" code into
     new webpack.optimize.CommonsChunkPlugin(
       'vendor', // chunk name

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = {
     extensions: [ '', '.js', '.jsx' ]
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     // Extract the "vendor" code into
     new webpack.optimize.CommonsChunkPlugin(
       'vendor', // chunk name


### PR DESCRIPTION
### Description of the problem this pull request fixes

Set up redux store for the project. 

Changes proposed in this pull request:
- Adds redux, redux-react, immutable.js and  Webpack hot module replacement for reducers to package.json
- create a store
- add a combiner for reducers
- sample reducer for a todo app, not to be used for us, but to show what it looks like
- add provider to index.jsx

**TODO:**   
- [x] make store immutable 
- [x] linting (lol)
- [ ] tests

other notes:

I am using this convention:

```
var foo = function(){};
module.export = foo
```

instead of 

```
module.export = function(){};
```

because it makes it easier for me to step through code when a require fails. 
