### PR TITLE
Fix expandedLayer reducer to properly utilize Immutable.js

### DIFF
--- a/src/js/components/LayerList.jsx
+++ b/src/js/components/LayerList.jsx
@@ -14,7 +14,7 @@ var MARGIN_LEFT = 10;
 
 function mapStateToProps(reduxState, ownProps) {
   var selectedMarkId = reduxState.get('selectedMark'),
-      expandedLayers = reduxState.get('expandedLayers');
+      expandedLayers = reduxState.get('expandedLayers').toJS();
 
   return {
     selected: selectedMarkId,

--- a/src/js/reducers/expandedLayers.js
+++ b/src/js/reducers/expandedLayers.js
@@ -1,27 +1,24 @@
 /* eslint new-cap:0 */
 'use strict';
 
-var assign = require('object-assign');
-var Immutable = require('immutable');
+var Immutable = window.Immutable = require('immutable');
 
 function selectedMarkReducer(state, action) {
-  var newState;
   if (typeof state === 'undefined') {
     return Immutable.Map();
   }
   if (action.type === 'EXPAND_LAYERS') {
-    newState = action.layerIds.reduce(function(layers, layerId) {
+    return state.merge(action.layerIds.reduce(function(layers, layerId) {
       layers[layerId] = true;
       return layers;
-    }, {});
-    return assign({}, state, newState);
+    }, {}));
   }
   if (action.type === 'TOGGLE_LAYERS') {
-    newState = action.layerIds.reduce(function(layers, layerId) {
-      layers[layerId] = !state[layerId];
+    return state.merge(action.layerIds.reduce(function(layers, layerId) {
+      // .get does not coerce numbers to strings, so we do that ourselves
+      layers[layerId] = !state.get('' + layerId);
       return layers;
-    }, {});
-    return assign({}, state, newState);
+    }, {}));
   }
   return state;
 }


### PR DESCRIPTION
This resolves the reducer logic issue described in #301 - the issue turned out to be that the `.get` method on an Immutable.Map does not coerce arguments to a string.
