### PR TITLE
Make signals code slightly more obvious/readable

### DIFF
--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -1,9 +1,10 @@
 'use strict';
 var dl = require('datalib'),
     ns = require('../../util/ns'),
-    signals, defaults;
+    defaults = require('./defaults'),
+    signals = defaults.signals;
 
-var api = module.exports = function() {
+function api() {
   return signals;
 };
 
@@ -71,7 +72,9 @@ api.value = value;
 api.stash = stash;
 api.streams = streams;
 
-dl.extend(api, defaults = require('./defaults'));
-signals = api.signals;
+// Extend the signals API with defaults, excepting the names & signals properties
+dl.extend(api, defaults);
 delete api.signals;
 delete api.names;
+
+module.exports = api;


### PR DESCRIPTION
### Description of the problem this pull request fixes

The signals code currently uses control flow structures that can be considered unintuitive (one liners of the form `return (some = expression), thingToReturn;` should generally be avoided because they can obfuscate what's wrong in error stack traces, given that return and assignment are mixed on one line), and the way in which the defaults are pulled in is hard to reason about. This PR re-structures the code in a small way to make it easier to see what is being exported.

There's more cleanup to be done, this was just what I knocked out while debugging an unrelated issue.

No logical changes; @arvind at this point I think Sue's got the logic fairly in hand, but this file could use a few more functional comments if you have any bandwidth.
