### PR TITLE
Implement pure export functions

### DIFF
--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -6,6 +6,18 @@ var dl = require('datalib'),
     lookup = model.lookup,
     names = {};
 
+// To prevent name collisions.
+function rename(name) {
+  if (!name) {
+    name = '';
+  }
+  var count = 0;
+  while (names[name]) {
+    name += ++count;
+  }
+  return (names[name] = 1, name);
+}
+
 /**
  * @classdesc A Lyra Scale Primitive.
  *
@@ -46,15 +58,6 @@ function Scale(name, type, domain, range) {
 inherits(Scale, Primitive);
 Scale.prototype.parent = null;
 
-// To prevent name collisions.
-function rename(name) {
-  var count = 0;
-  while (names[name]) {
-    name += ++count;
-  }
-  return (names[name] = 1, name);
-}
-
 // Exports FieldIDs to DataRefs. We don't default to the last option as the
 // structure has performance implications in Vega. Most-least performant:
 //   {"data": ..., "field": ...} for a single field
@@ -65,12 +68,13 @@ function fmap(f) {
 }
 
 function dataRef(ref) {
+  console.log(ref);
   var sets = {},
       data, field, i, len, keys;
 
   if (ref.length === 1 && (ref = ref[0])) {
     field = lookup(ref);
-    return {data: field.parent().name, field: field._name};
+    ref = {data: field.parent().name, field: field._name};
   } else {
     for (i = 0, len = ref.length; i < len; ++i) {
       field = lookup(ref[i]);
@@ -96,6 +100,7 @@ function dataRef(ref) {
       }
     }
   }
+  return ref;
 }
 
 Scale.prototype.export = Scale.prototype.manipulators = function(resolve) {

--- a/src/js/model/primitives/marks/Group.js
+++ b/src/js/model/primitives/marks/Group.js
@@ -38,7 +38,6 @@ function Group() {
   return this;
 }
 
-
 var CHILDREN = {
   group: Group,
   rect: require('./Rect'),
@@ -106,5 +105,7 @@ Group.prototype.child = function(type, child) {
   }
   return child.parent ? child.parent(this._id) : child;
 };
+
+Group.CHILD_TYPES = CHILD_TYPES;
 
 module.exports = Group;

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -3,6 +3,10 @@
 
 var expect = require('chai').expect;
 
+// Pull in a fresh signals module so we can clean-initialize values used in tests
+delete require.cache[require.resolve('../../../model/signals')];
+var sg = require('../../../model/signals');
+
 var Group = require('./Group');
 var Mark = require('./Mark');
 
@@ -94,6 +98,24 @@ describe('Group Mark', function() {
       expect(otherGroup.parent()).not.to.equal(group);
       group.child('marks.group', otherGroup);
       expect(otherGroup.parent()).to.equal(group);
+    });
+
+  });
+
+  describe('export method', function() {
+
+    it('is a function', function() {
+      expect(group).to.have.property('export');
+      expect(group.export).to.be.a('function');
+    });
+
+    it('renders the group to a vega spec object', function() {
+      // Group initializes with signals for width and height that depend on the
+      // overall visualization's dimensions having been set
+      sg.init('vis_width', 500);
+      sg.init('vis_height', 500);
+      var result = group.export();
+      expect(result).to.be.an('object');
     });
 
   });

--- a/src/js/util/export.js
+++ b/src/js/util/export.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var dl = require('datalib'),
+    sg = require('../model/signals'),
+    Guide = require('../model/primitives/Guide'),
+    Mark = require('../model/primitives/marks/Mark');
+
+/**
+ * Utility method to clean a spec object
+ * @param {Object} spec - A Lyra representation of a Vega spec
+ * @param {Boolean} shouldClean - Whether to clean Lyra-specific values
+ * @return {Object} A cleaned spec object
+ */
+function _clean(spec, shouldClean) {
+  var key, prop, cleanKey;
+  for (key in spec) {
+    prop = spec[key];
+    cleanKey = key.startsWith('_');
+    cleanKey = cleanKey || prop._disabled || prop === undefined;
+    if (cleanKey) {
+      delete spec[key];
+    } else if (dl.isObject(prop)) {
+      if (prop.signal && shouldClean !== false) {
+        // Render signals to their value
+        spec[key] = sg.value(prop.signal);
+      } else {
+        // Recurse
+        spec[key] = _clean(spec[key], shouldClean);
+      }
+    }
+  }
+
+  return spec;
+}
+
+function exportGuide(guide, shouldClean) {
+  var spec = exportPrimitive(guide, shouldClean),
+      guideType = guide._gtype,
+      type = guide._type;
+
+  if (guideType === Guide.TYPES.AXIS) {
+    spec.scale = model.lookup(spec.scale).name;
+  } else if (gtype === Guide.TYPES.LEGEND) {
+    spec[type] = model.lookup(spec[type]).name;
+  }
+
+  return spec;
+}
+
+function exportMark(mark, shouldClean) {
+  var spec = exportPrimitive(mark, shouldClean),
+      props = spec.properties,
+      update = props.update,
+      from = mark.from && model.lookup(mark.from),
+      keys = dl.keys(update);
+
+  if (from) {
+    spec.from = (from instanceof Mark) ?
+      { mark: from.name } :
+      { data: from.name };
+  }
+
+  keys.forEach(function(key) {
+    var val = update[key];
+
+    // signalRef resolved to literal
+    if (!dl.isObject(val)) {
+      update[key] = {
+        value: val
+      };
+    }
+
+    // Parse reference values out to their associated primitive's name
+    if (val.scale) {
+      val.scale = lookup(val.scale).name;
+    }
+    if (val.field) {
+      val.field = lookup(val.field)._name;
+    }
+    if (val.group) {
+      val.field = {
+        group: val.group
+      };
+    }
+  });
+
+  if (!shouldClean) {
+    spec.lyra_id = mark._id;
+  }
+
+  return spec;
+}
+
+function exportPrimitive(primitive, shouldClean) {
+  return _clean(dl.duplicate(primitive), shouldClean);
+}
+
+module.exports = {
+  _clean: _clean,
+  guide: exportGuide,
+  mark: exportMark,
+  primitive: exportPrimitive
+};

--- a/src/js/util/exporter.js
+++ b/src/js/util/exporter.js
@@ -40,7 +40,7 @@ function exportGuide(guide, shouldClean) {
 
   if (guideType === Guide.TYPES.AXIS) {
     spec.scale = model.lookup(spec.scale).name;
-  } else if (gtype === Guide.TYPES.LEGEND) {
+  } else if (guideType === Guide.TYPES.LEGEND) {
     spec[type] = model.lookup(spec[type]).name;
   }
 

--- a/src/js/util/exporter.js
+++ b/src/js/util/exporter.js
@@ -49,8 +49,7 @@ function exportGroup(group, shouldClean) {
 
   // Recursively clean children
   Group.CHILD_TYPES.forEach(function(childType) {
-    console.log(childType);
-    spec[childType] = mark[childType].map(cleanChild);
+    spec[childType] = group[childType].map(cleanChild);
   });
   return spec;
 }

--- a/src/js/util/exporter.test.js
+++ b/src/js/util/exporter.test.js
@@ -3,6 +3,10 @@
 var expect = require('chai').expect;
 var exporter = require('./exporter');
 
+// Pull in a fresh signals module so we can clean-initialize values used in tests
+delete require.cache[require.resolve('../model/signals')];
+var sg = require('../model/signals');
+
 var Area = require('../model/primitives/marks/Area');
 var Group = require('../model/primitives/marks/Group');
 var Guide = require('../model/primitives/Guide');
@@ -16,6 +20,11 @@ var Symbol = require('../model/primitives/marks/Symbol');
 var Text = require('../model/primitives/marks/Text');
 
 describe('exporter utility', function() {
+
+  before(function() {
+    sg.init('vis_width', 500);
+    sg.init('vis_height', 500);
+  });
 
   [
     // { Ctor: Area, name: 'area' },

--- a/src/js/util/exporter.test.js
+++ b/src/js/util/exporter.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var expect = require('chai').expect;
+var exporter = require('./exporter');
+
+/*
+- [ ] Area
+- [ ] Group
+- [x] Guide
+- [ ] Line
+- [x] Mark
+- [x] Primitive
+- [-] Rect
+- [-] Scale
+- [-] Scene
+- [-] Symbol
+- [-] Text
+*/
+
+var Area = require('../model/primitives/marks/Area');
+var Group = require('../model/primitives/marks/Group');
+var Guide = require('../model/primitives/Guide');
+var Line = require('../model/primitives/marks/Line');
+var Mark = require('../model/primitives/marks/Mark');
+var Primitive = require('../model/primitives/Primitive');
+var Rect = require('../model/primitives/marks/Rect');
+var Scale = require('../model/primitives/Scale');
+var Scene = require('../model/primitives/marks/Scene');
+var Symbol = require('../model/primitives/marks/Symbol');
+var Text = require('../model/primitives/marks/Text');
+
+// Utility methods borrowed from jQuery 1.12
+var hasOwn = ({}).hasOwnProperty;
+function isPlainObject(obj) {
+  // Not plain objects:
+  // - Any object or value whose internal [[Class]] property is not "[object Object]"
+  // - DOM nodes
+  if (typeof obj !== "object" || obj.nodeType) {
+    return false;
+  }
+
+  if ( obj.constructor &&
+      ! hasOwn.call( obj.constructor.prototype, 'isPrototypeOf' ) ) {
+    return false;
+  }
+
+  // If the function hasn't returned already, we're confident that
+  // |obj| is a plain object, created by {} or constructed with new Object
+  return true;
+}
+
+describe('exporter utility', function() {
+
+  [
+    // { Ctor: Area, name: 'area' },
+    // { Ctor: Group, name: 'group' },
+    { Ctor: Guide, name: 'guide' },
+    // { Ctor: Line, name: 'line' },
+    { Ctor: Mark, name: 'mark' },
+    { Ctor: Primitive, name: 'primitive' },
+    // { Ctor: Rect, name: 'rect' },
+    // { Ctor: Scale, name: 'scale' },
+    // { Ctor: Scene, name: 'scene' },
+    // { Ctor: Symbol, name: 'symbol' },
+    // { Ctor: Text, name: 'text' }
+  ].forEach(function(primitive) {
+    var name = primitive.name;
+    var upperName = name[0].toUpperCase() + name.slice(1);
+    var Ctor = primitive.Ctor;
+
+    describe(upperName + ' exporter', function() {
+      var exporterFn, instance;
+
+      beforeEach(function() {
+        exporterFn = exporter[name];
+        instance = new Ctor();
+      });
+
+      it('is a function', function() {
+        expect(exporterFn).to.be.a('function');
+      });
+
+      it('returns an object', function() {
+        var result = exporterFn(instance);
+        expect(result).to.be.an('object');
+      });
+
+      it('returns a vanilla object', function() {
+        var result = exporterFn(instance);
+        expect(result).to.be.an('object');
+        expect(isPlainObject(result)).to.equal(true);
+      });
+
+      // Compatibility test
+      it('returns an object equivalent to ' + upperName + '.export()', function() {
+        var utilityFnExportResult = exporterFn(instance);
+        var prototypeExportResult = instance.export();
+        expect(utilityFnExportResult).not.to.equal(prototypeExportResult);
+        expect(utilityFnExportResult).to.deep.equal(prototypeExportResult);
+      });
+
+    });
+  });
+
+});

--- a/src/js/util/exporter.test.js
+++ b/src/js/util/exporter.test.js
@@ -3,20 +3,6 @@
 var expect = require('chai').expect;
 var exporter = require('./exporter');
 
-/*
-- [ ] Area
-- [ ] Group
-- [x] Guide
-- [ ] Line
-- [x] Mark
-- [x] Primitive
-- [-] Rect
-- [-] Scale
-- [-] Scene
-- [-] Symbol
-- [-] Text
-*/
-
 var Area = require('../model/primitives/marks/Area');
 var Group = require('../model/primitives/marks/Group');
 var Guide = require('../model/primitives/Guide');
@@ -29,31 +15,11 @@ var Scene = require('../model/primitives/marks/Scene');
 var Symbol = require('../model/primitives/marks/Symbol');
 var Text = require('../model/primitives/marks/Text');
 
-// Utility methods borrowed from jQuery 1.12
-var hasOwn = ({}).hasOwnProperty;
-function isPlainObject(obj) {
-  // Not plain objects:
-  // - Any object or value whose internal [[Class]] property is not "[object Object]"
-  // - DOM nodes
-  if (typeof obj !== "object" || obj.nodeType) {
-    return false;
-  }
-
-  if ( obj.constructor &&
-      ! hasOwn.call( obj.constructor.prototype, 'isPrototypeOf' ) ) {
-    return false;
-  }
-
-  // If the function hasn't returned already, we're confident that
-  // |obj| is a plain object, created by {} or constructed with new Object
-  return true;
-}
-
 describe('exporter utility', function() {
 
   [
     // { Ctor: Area, name: 'area' },
-    // { Ctor: Group, name: 'group' },
+    { Ctor: Group, name: 'group' },
     { Ctor: Guide, name: 'guide' },
     // { Ctor: Line, name: 'line' },
     { Ctor: Mark, name: 'mark' },
@@ -61,8 +27,8 @@ describe('exporter utility', function() {
     // { Ctor: Rect, name: 'rect' },
     // { Ctor: Scale, name: 'scale' },
     // { Ctor: Scene, name: 'scene' },
-    // { Ctor: Symbol, name: 'symbol' },
-    // { Ctor: Text, name: 'text' }
+    { Ctor: Symbol, name: 'symbol' },
+    { Ctor: Text, name: 'text' }
   ].forEach(function(primitive) {
     var name = primitive.name;
     var upperName = name[0].toUpperCase() + name.slice(1);
@@ -85,16 +51,18 @@ describe('exporter utility', function() {
         expect(result).to.be.an('object');
       });
 
-      it('returns a vanilla object', function() {
-        var result = exporterFn(instance);
-        expect(result).to.be.an('object');
-        expect(isPlainObject(result)).to.equal(true);
-      });
-
       // Compatibility test
       it('returns an object equivalent to ' + upperName + '.export()', function() {
         var utilityFnExportResult = exporterFn(instance);
         var prototypeExportResult = instance.export();
+        expect(utilityFnExportResult).not.to.equal(prototypeExportResult);
+        expect(utilityFnExportResult).to.deep.equal(prototypeExportResult);
+      });
+
+      // Compatibility test
+      it('returns an object equivalent to ' + upperName + '.export(true)', function() {
+        var utilityFnExportResult = exporterFn(instance, true);
+        var prototypeExportResult = instance.export(true);
         expect(utilityFnExportResult).not.to.equal(prototypeExportResult);
         expect(utilityFnExportResult).to.deep.equal(prototypeExportResult);
       });

--- a/src/js/util/exporter.test.js
+++ b/src/js/util/exporter.test.js
@@ -79,4 +79,56 @@ describe('exporter utility', function() {
     });
   });
 
+  describe('for nested groups', function() {
+    var group1, group2;
+
+    beforeEach(function() {
+      group1 = new Group();
+      group1.child('marks.rect');
+      group2 = group1.child('marks.group');
+      group2.child('marks.rect');
+      group2.child('scales');
+    });
+
+    it('is equivalent to Group.prototype.export(true)', function() {
+      var utilityFnExportResult = exporter.group(group1, true);
+      var prototypeExportResult = group1.export(true);
+      expect(utilityFnExportResult).not.to.equal(prototypeExportResult);
+      expect(utilityFnExportResult).to.deep.equal(prototypeExportResult);
+      console.log(utilityFnExportResult);
+    });
+
+    it('exports a well-formed result', function() {
+      var result = exporter.group(group1, true);
+      expect(result).to.be.an('object');
+      expect(result).to.have.property('type');
+      expect(result.type).to.equal('group');
+
+      expect(result).to.have.property('marks');
+      expect(result.marks).to.be.an('array');
+      expect(result.marks.length).to.equal(2);
+
+      var child1 = result.marks[0];
+      expect(child1).to.be.an('object');
+      expect(child1).to.have.property('type');
+      expect(child1.type).to.equal('rect');
+
+      var child2 = result.marks[1];
+      expect(child2).to.be.an('object');
+      expect(child2).to.have.property('type');
+      expect(child2.type).to.equal('group');
+
+      expect(child2).to.have.property('marks');
+      expect(child2.marks).to.be.an('array');
+      expect(child2.marks.length).to.equal(1);
+      expect(child2.marks[0]).to.have.property('type');
+      expect(child2.marks[0].type).to.equal('rect');
+
+      expect(child2).to.have.property('scales');
+      expect(child2.scales).to.be.an('array');
+      expect(child2.scales.length).to.equal(1);
+    });
+
+  });
+
 });

--- a/src/js/util/exporter.test.js
+++ b/src/js/util/exporter.test.js
@@ -27,17 +27,17 @@ describe('exporter utility', function() {
   });
 
   [
-    // { Ctor: Area, name: 'area' },
-    { Ctor: Group, name: 'group' },
-    { Ctor: Guide, name: 'guide' },
-    // { Ctor: Line, name: 'line' },
-    { Ctor: Mark, name: 'mark' },
-    { Ctor: Primitive, name: 'primitive' },
-    // { Ctor: Rect, name: 'rect' },
-    // { Ctor: Scale, name: 'scale' },
-    // { Ctor: Scene, name: 'scene' },
-    { Ctor: Symbol, name: 'symbol' },
-    { Ctor: Text, name: 'text' }
+    {Ctor: Area, name: 'area'},
+    {Ctor: Group, name: 'group'},
+    {Ctor: Guide, name: 'guide'},
+    {Ctor: Line, name: 'line'},
+    {Ctor: Mark, name: 'mark'},
+    {Ctor: Primitive, name: 'primitive'},
+    {Ctor: Rect, name: 'rect'},
+    {Ctor: Scale, name: 'scale'},
+    {Ctor: Scene, name: 'scene'},
+    {Ctor: Symbol, name: 'symbol'},
+    {Ctor: Text, name: 'text'}
   ].forEach(function(primitive) {
     var name = primitive.name;
     var upperName = name[0].toUpperCase() + name.slice(1);


### PR DESCRIPTION
### Description of the problem this pull request fixes

The current export logic is resource-based and leverages the model instance-ness of primitives. As we move to redux we will want to make the primitives be stored as immutable, raw objects rather than mutable instances; in order to anticipate this shift I have begun to convert the exporter logic into utility functions.

Currently I'm running into trouble where any primitive with signal values will not successfully pass through the primitive export method: there's an exception within the signal code relating to `sg.init`. PR'ing so @deathbearbrown can take a look.

To test, pull down branch and run the unit test suite.
