### PR TITLE
Begin de-abstracting the internals of the signal module & interface

### DIFF
--- a/src/js/components/LayerList.jsx
+++ b/src/js/components/LayerList.jsx
@@ -45,7 +45,7 @@ function mapDispatchToProps(dispatch, ownProps) {
       // If an item was found, set the Lyra mode signal so that the handles appear.
       // As noted above, this logic should probably not exist here!
       if (item !== null) {
-        sg.setValue(sg.SELECTED, item);
+        model.signal(sg.SELECTED, item);
         model.update();
       }
       // END unwanted side-effect-y code

--- a/src/js/components/LayerList.jsx
+++ b/src/js/components/LayerList.jsx
@@ -45,7 +45,8 @@ function mapDispatchToProps(dispatch, ownProps) {
       // If an item was found, set the Lyra mode signal so that the handles appear.
       // As noted above, this logic should probably not exist here!
       if (item !== null) {
-        model.signal(sg.SELECTED, item).update();
+        sg.setValue(sg.SELECTED, item);
+        model.update();
       }
       // END unwanted side-effect-y code
     },

--- a/src/js/components/mixins/Parse.jsx
+++ b/src/js/components/mixins/Parse.jsx
@@ -21,7 +21,8 @@ module.exports = {
       // If an item was found, set the Lyra mode signal so that the handles appear.
       // As noted above, this logic should probably not exist here!
       if (item !== null) {
-        model.signal(sg.SELECTED, item).update();
+        sg.value(sg.SELECTED, item);
+        model.update();
       }
     });
   }

--- a/src/js/components/mixins/SignalValue.jsx
+++ b/src/js/components/mixins/SignalValue.jsx
@@ -1,12 +1,13 @@
 'use strict';
 var dl = require('datalib'),
+    signals = require('../../model/signals'),
     model = require('../../model');
 
 module.exports = {
   getInitialState: function() {
     var props = this.props;
     return {
-      value: props.signal ? model.signal(props.signal) : props.value
+      value: props.signal ? signals.getValue(props.signal) : props.value
     };
   },
 
@@ -29,7 +30,7 @@ module.exports = {
     }
     if (nextProps.signal || nextProps.value !== prevProps.value) {
       this.setState({value: nextProps.signal ?
-        model.signal(nextProps.signal) : nextProps.value});
+        signals.getValue(nextProps.signal) : nextProps.value});
     }
   },
 
@@ -60,13 +61,19 @@ module.exports = {
         signal = props.signal,
         type = props.type;
 
-    value = (type === 'number' || type === 'range') ? +value : value;
+    if (type === 'number' || type === 'range') {
+      // Ensure value is a number
+      value = +value;
+    }
 
     if (signal) {
-      model.signal(signal, value).update();
+      model.signal(signal, value);
+      model.update();
     } else {
       this._set(props.obj, value);
-      this.setState({value: value});
+      this.setState({
+        value: value
+      });
     }
   }
 };

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -75,7 +75,8 @@ var DataTable = React.createClass({
   },
 
   handleDragStart: function(evt) {
-    model.signal(sg.MODE, 'channels').update();
+    model.signal(sg.MODE, 'channels');
+    model.update();
   },
 
   handleDragOver: function(evt) {

--- a/src/js/model/index.js
+++ b/src/js/model/index.js
@@ -89,7 +89,8 @@ function register() {
       }
       model._shiftKey = shiftKey;
       var setAltChan = mode === 'altchannels' ? 'channels' : mode;
-      model.signal(sg.MODE, mode === 'channels' ? 'altchannels' : setAltChan).update();
+      model.signal(sg.MODE, mode === 'channels' ? 'altchannels' : setAltChan);
+      model.update();
     });
   }
 
@@ -253,10 +254,11 @@ model.parse = function(el) {
 
 /**
  * Re-renders the current spec (e.g., to account for new signal values).
- * @returns {Object} The Lyra model.
  */
 model.update = function() {
-  return (model.view.update(), model);
+  if (model.view && model.view.update && typeof model.view.update === 'function') {
+    model.view.update();
+  }
 };
 
 /**
@@ -267,7 +269,8 @@ model.update = function() {
  * @returns {Object} The Lyra model.
  */
 model.onSignal = function(name, handler) {
-  var listener = listeners[name] || (listeners[name] = []);
+  listeners[name] = listeners[name] || [];
+  var listener = listeners[name];
   listener.push(handler);
   if (model.view) {
     model.view.onSignal(name, handler);
@@ -283,7 +286,8 @@ model.onSignal = function(name, handler) {
  * @returns {Object} The Lyra model.
  */
 model.offSignal = function(name, handler) {
-  var listener = listeners[name] || (listeners[name] = []);
+  listeners[name] = listeners[name] || [];
+  var listener = listeners[name];
   for (var i = listener.length; --i >= 0;) {
     if (!handler || listener[i] === handler) {
       listener.splice(i, 1);

--- a/src/js/model/index.js
+++ b/src/js/model/index.js
@@ -146,8 +146,8 @@ model.scale = function(id) {
  * @returns {*} The signal value if called as a getter, the model if called as
  * a setter.
  */
-model.signal = function(name, val) {
-  if (typeof val === 'undefined') {
+model.signal = function(name, value) {
+  if (typeof value === 'undefined') {
     return sg.getValue(name);
   }
   var ret = sg.value.apply(sg, arguments);
@@ -254,6 +254,7 @@ model.parse = function(el) {
 
 /**
  * Re-renders the current spec (e.g., to account for new signal values).
+ * @returns {void}
  */
 model.update = function() {
   if (model.view && model.view.update && typeof model.view.update === 'function') {

--- a/src/js/model/index.js
+++ b/src/js/model/index.js
@@ -145,7 +145,10 @@ model.scale = function(id) {
  * @returns {*} The signal value if called as a getter, the model if called as
  * a setter.
  */
-model.signal = function() {
+model.signal = function(name, val) {
+  if (typeof val === 'undefined') {
+    return sg.getValue(name);
+  }
   var ret = sg.value.apply(sg, arguments);
   return ret === sg ? model : ret;
 };

--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -32,7 +32,7 @@ function _clean(spec, clean) {
     if (c) {
       delete spec[k];
     } else if (dl.isObject(p)) {
-      spec[k] = p.signal && cln ? sg.value(p.signal) : _clean(spec[k], clean);
+      spec[k] = p.signal && cln ? sg.getValue(p.signal) : _clean(spec[k], clean);
     }
   }
 

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -41,8 +41,8 @@ Scene.prototype.export = function(resolve) {
   var spec = Group.prototype.export.call(this, resolve);
 
   // Always resolve width/height signals.
-  spec.width = spec.width.signal ? sg.value(SG_WIDTH) : spec.width;
-  spec.height = spec.height.signal ? sg.value(SG_HEIGHT) : spec.height;
+  spec.width = spec.width.signal ? sg.getValue(SG_WIDTH) : spec.width;
+  spec.height = spec.height.signal ? sg.getValue(SG_HEIGHT) : spec.height;
 
   // Remove mark-specific properties
   delete spec.type;

--- a/src/js/model/rules/marks.js
+++ b/src/js/model/rules/marks.js
@@ -18,7 +18,8 @@ function bindProperty(map, property, props, def, from) {
     }
   }
   if (typeof d.value !== 'undefined') {
-    model.signal(p.signal = propSg(this, property), d.value);
+    p.signal = propSg(this, property);
+    model.signal(p.signal, d.value);
   }
 
   if (typeof d.band !== 'undefined') {

--- a/src/js/model/signals/defaults.js
+++ b/src/js/model/signals/defaults.js
@@ -83,11 +83,13 @@ signals[CURSOR] = {
 module.exports = {
   signals: signals,
   names: [SELECTED, MODE, ANCHOR, DELTA, CELL, MOUSE, CURSOR],
-  SELECTED: SELECTED,
-  MODE: MODE,
-  ANCHOR: ANCHOR,
-  DELTA: DELTA,
-  CURSOR: CURSOR,
-  CELL: CELL,
-  MOUSE: MOUSE
+  signalNames: {
+    SELECTED: SELECTED,
+    MODE: MODE,
+    ANCHOR: ANCHOR,
+    DELTA: DELTA,
+    CURSOR: CURSOR,
+    CELL: CELL,
+    MOUSE: MOUSE
+  }
 };

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -26,10 +26,26 @@ api.init = function(name, val) {
   return ref(name);
 }
 
+api.getValue = function(name) {
+  var model = require('../'),
+      // `view` is a vega runtime component; view.signal is a getter/setter
+      view = model.view,
+      signalObj = signals[ns(name)];
+
+  // Wrap signal accessors in a try/catch in case view doesn't exist,
+  // or signal hasn't been registered yet with the view.
+  try {
+    return view.signal(name);
+  } catch (e) {
+    return signalObj.init;
+  }
+}
+
 api.value = function(name, val) {
   var model = require('../'),
+      // `view` is a vega runtime component; view.signal is a getter/setter
       view = model.view,
-      signalObj = signals[name = ns(name)],
+      signalObj = signals[ns(name)],
       calledAsSetter = arguments.length === 2;
 
   // Wrap signal accessors in a try/catch in case view doesn't exist,

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -6,7 +6,7 @@ var dl = require('datalib'),
 
 function api() {
   return signals;
-};
+}
 
 // Augment the signals API with properties like SELECTED that define the
 // strings used to identify and trigger a given signal
@@ -24,7 +24,7 @@ api.init = function(name, val) {
     _idx: dl.keys(signals).length
   };
   return ref(name);
-}
+};
 
 api.getValue = function(name) {
   var model = require('../'),
@@ -39,7 +39,7 @@ api.getValue = function(name) {
   } catch (e) {
     return signalObj.init;
   }
-}
+};
 
 api.value = function(name, val) {
   var model = require('../'),
@@ -59,7 +59,7 @@ api.value = function(name, val) {
     }
     return calledAsSetter ? api : signalObj.init;
   }
-}
+};
 
 // Stash current signal values from the view into our model
 // to allow seamless re-renders.
@@ -70,17 +70,17 @@ api.stash = function() {
     return signals;
   }
 
-  for (var k in signals) {
-    if (defaults.names.indexOf(k) >= 0) {
+  for (var key in signals) {
+    if (defaults.names.indexOf(key) >= 0) {
       continue;
     }
-    try {
-      signals[k].init = view.signal(k);
-    } catch (e) {}
+    if (view && typeof view.signal === 'function') {
+      signals[key].init = view.signal(key);
+    }
   }
 
   return signals;
-}
+};
 
 api.streams = function(name, def) {
   var sg = signals[ns(name)];
@@ -89,6 +89,6 @@ api.streams = function(name, def) {
   }
   sg.streams = def;
   return api;
-}
+};
 
 module.exports = api;


### PR DESCRIPTION
The code paths within the Signal module are very layered and difficult to trace; this PR begins to peel apart the combined getter and setter and the `model.signal` wrapper method in favor of explicitly calling getter or setters exposed by the signals API and manually triggering view updates via a call to model rather than relying on an overloaded return value from the signal's `.view` and model's `.signal` methods.

The code as-is exacerbates an existing issue where dragging data onto channels may not take effect, so this probably needs more work before it is safe to merge. I am submitting it as an early PR so that @deathbearbrown can see my thinking.

(Another major change here is that it re-structures the signals module code to be less different from the other modules)
