### PR TITLE
Add hierarchy utilities to get the parents or children of a mark

### DIFF
--- a/src/js/util/hierarchy.js
+++ b/src/js/util/hierarchy.js
@@ -1,6 +1,17 @@
 'use strict';
 
 /**
+ * Find the parent item for a given mark.
+ *
+ * @param {Primitive} mark - A mark for which to return the parent mark
+ * @returns {Primitive|null} The requested mark, if present, else null
+ */
+function getParent(mark) {
+  // Require model in here to avoid circular dependency issue
+  return require('../model').lookup(mark._parent) || null;
+}
+
+/**
  * Get all parent nodes for a given primitive in the Lyra hierarchy, i.e. all
  * groups which may be considered to be ancestors of the provided primitive.
  *
@@ -11,13 +22,13 @@ function getParents(primitive) {
   if (!primitive) {
     return [];
   }
-  var current = primitive.parent && primitive.parent();
+  var current = primitive._parent && getParent(primitive);
   if (!current) {
     return [];
   }
   var parents = [current];
-  while (current && current.parent && typeof current.parent === 'function') {
-    current = current.parent();
+  while (current && current._parent) {
+    current = getParent(current);
     if (current) {
       parents.push(current);
     }
@@ -85,6 +96,7 @@ function findInItemTree(item, path) {
 }
 
 module.exports = {
+  getParent: getParent,
   getParentGroupIds: getParentGroupIds,
   getParents: getParents,
   getGroupIds: getGroupIds,

--- a/src/js/util/hierarchy.js
+++ b/src/js/util/hierarchy.js
@@ -7,8 +7,32 @@
  * @returns {Primitive|null} The requested mark, if present, else null
  */
 function getParent(mark) {
-  // Require model in here to avoid circular dependency issue
+  // Require model in here to sidestep circular dependency issue
   return require('../model').lookup(mark._parent) || null;
+}
+
+/**
+ * Return all child primitives of the provided group.
+ *
+ * @param {Group} groupMark - The group for which to return children
+ * @returns {Object[]} Array of instantiated primitive objects that are children
+ * of the provided group mark
+ */
+function getChildren(groupMark) {
+  // Require model in here to sidestep circular dependency issue
+  var lookup = require('../model').lookup;
+
+  return ['scales', 'legends', 'axes', 'marks'].reduce(function(allChildren, childType) {
+    if (!groupMark[childType]) {
+      return allChildren;
+    }
+    return allChildren.concat(groupMark[childType].map(function(childId) {
+      return lookup(childId);
+    }));
+  }, []).filter(function(mark) {
+    // Filter out any null or undefined results, in case an invalid ID is present
+    return !!mark;
+  });
 }
 
 /**
@@ -97,6 +121,7 @@ function findInItemTree(item, path) {
 
 module.exports = {
   getParent: getParent,
+  getChildren: getChildren,
   getParentGroupIds: getParentGroupIds,
   getParents: getParents,
   getGroupIds: getGroupIds,

--- a/src/js/util/hierarchy.test.js
+++ b/src/js/util/hierarchy.test.js
@@ -35,6 +35,48 @@ describe('hierarchy utilities', function() {
 
   });
 
+  describe('getChildren', function() {
+    var getChildren;
+
+    beforeEach(function() {
+      getChildren = hierarchy.getChildren;
+    });
+
+    it('is a function', function() {
+      expect(getChildren).to.be.a('function');
+    });
+
+    it('returns an empty array for childless groups', function() {
+      var group = new Group(),
+          result = getChildren(group);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns an array of all children of the provided group', function() {
+      var group = new Group(),
+          child1 = group.child('scales'),
+          child2 = group.child('axes'),
+          child3 = group.child('marks.group'),
+          child4 = group.child('marks.rect'),
+          result = getChildren(group);
+      expect(result).to.deep.equal([child1, child2, child3, child4]);
+    });
+
+    it('omits invalid IDs from the returned array', function() {
+      var group = new Group();
+      group.marks.push('invalidID1', 'invalidID2');
+      var result = getChildren(group);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns an empty array for non-group marks', function() {
+      var rect = new Rect(),
+          result = getChildren(rect);
+      expect(result).to.deep.equal([]);
+    });
+
+  });
+
   describe('getParents', function() {
     var getParents;
 

--- a/src/js/util/hierarchy.test.js
+++ b/src/js/util/hierarchy.test.js
@@ -9,11 +9,41 @@ var hierarchy = require('./hierarchy');
 
 describe('hierarchy utilities', function() {
 
+  describe('getParent', function() {
+    var getParent;
+
+    beforeEach(function() {
+      getParent = hierarchy.getParent;
+    });
+
+    it('is a function', function() {
+      expect(getParent).to.be.a('function');
+    });
+
+    it('returns the parent of a provided mark', function() {
+      var parent = new Group(),
+          rect = parent.child('marks.rect'),
+          result = getParent(rect);
+      expect(result).to.equal(parent);
+    });
+
+    it('returns null if a mark was not found', function() {
+      var parentlessMark = new Rect(),
+          result = getParent(parentlessMark);
+      expect(result).to.be.null;
+    });
+
+  });
+
   describe('getParents', function() {
     var getParents;
 
     beforeEach(function() {
       getParents = hierarchy.getParents;
+    });
+
+    it('is a function', function() {
+      expect(getParents).to.be.a('function');
     });
 
     it('returns an empty array when called with no arguments', function() {
@@ -54,6 +84,10 @@ describe('hierarchy utilities', function() {
       getGroupIds = hierarchy.getGroupIds;
     });
 
+    it('is a function', function() {
+      expect(getGroupIds).to.be.a('function');
+    });
+
     it('returns an array', function() {
       expect(getGroupIds([])).to.be.an('array');
     });
@@ -75,6 +109,10 @@ describe('hierarchy utilities', function() {
 
     beforeEach(function() {
       getParentGroupIds = hierarchy.getParentGroupIds;
+    });
+
+    it('is a function', function() {
+      expect(getParentGroupIds).to.be.a('function');
     });
 
     it('returns an array when called with no arguments', function() {


### PR DESCRIPTION
**Description of the problem this pull request fixes**

Marks provide a `.parent()` method on their prototype, which looks up and returns that mark's parent by ID from the store. Additionally, groups provide a set of arrays that hold their child primitives, which you can access by looking up the IDs from each of a group's four child arrays by their IDs.

These methods provide tested functional utilities to accomplish both of these operations; moving this code into a shared utility (and not relying on the primitive prototype method as much) sets us up to make this something that can work with the existing primitive store _or_ the new redux store later on.

Changes proposed in this pull request:
- Add a `getParent(mark)` method to the `utils/hierarchy` module
- Add a `getChildren(mark)` method to the `utils/hierarchy` module

*\* If submitting code for review: **

**This PR includes:**
- [x] Tests
- [x] functional comments

Here you go, @deathbearbrown 
