### PR TITLE
Avoid generic identifiers like "Base"; prefer specificity

### DIFF
--- a/src/js/components/inspectors/Area.jsx
+++ b/src/js/components/inspectors/Area.jsx
@@ -2,9 +2,9 @@
 var React = require('react'),
     Property = require('./Property'),
     AreaProperty = require('./AreaProperty'),
-    Base = require('../../model/primitives/marks/Area');
+    Area = require('../../model/primitives/marks/Area');
 
-var Area = React.createClass({
+var AreaInspector = React.createClass({
   render: function() {
     var props = this.props,
         primitive = props.primitive,
@@ -77,7 +77,7 @@ var Area = React.createClass({
           label="Interpolate"
           primitive={primitive}
           type="select"
-          opts={Base.INTERPOLATE}
+          opts={Area.INTERPOLATE}
           canDrop={true}
           scale={update.interpolate.scale}
           field={update.interpolate.field}
@@ -100,7 +100,7 @@ var Area = React.createClass({
           label="Orient"
           primitive={primitive}
           type="select"
-          opts={Base.ORIENT}
+          opts={Area.ORIENT}
           canDrop={true}
           scale={update.orient.scale}
           field={update.orient.field}
@@ -111,4 +111,4 @@ var Area = React.createClass({
   }
 });
 
-module.exports = Area;
+module.exports = AreaInspector;

--- a/src/js/components/inspectors/Rect.jsx
+++ b/src/js/components/inspectors/Rect.jsx
@@ -3,7 +3,7 @@ var React = require('react'),
     Property = require('./Property'),
     ExtentProperty = require('./ExtentProperty');
 
-var Rect = React.createClass({
+var RectInspector = React.createClass({
   render: function() {
     var props = this.props,
         primitive = props.primitive,
@@ -47,4 +47,4 @@ var Rect = React.createClass({
   }
 });
 
-module.exports = Rect;
+module.exports = RectInspector;

--- a/src/js/components/inspectors/Symbol.jsx
+++ b/src/js/components/inspectors/Symbol.jsx
@@ -1,9 +1,9 @@
 'use strict';
 var React = require('react'),
     Property = require('./Property'),
-    Base = require('../../model/primitives/marks/Symbol');
+    Symbol = require('../../model/primitives/marks/Symbol');
 
-var Symbol = React.createClass({
+var SymbolInspector = React.createClass({
   render: function() {
     var props = this.props,
         primitive = props.primitive,
@@ -32,7 +32,7 @@ var Symbol = React.createClass({
           signal={update.size.signal} />
 
         <Property name="shape" label="Shape" primitive={primitive}
-          type="select" opts={Base.SHAPES} canDrop={true}
+          type="select" opts={Symbol.SHAPES} canDrop={true}
           scale={update.shape.scale} field={update.shape.field}
           signal={update.shape.signal} />
 
@@ -66,4 +66,4 @@ var Symbol = React.createClass({
   }
 });
 
-module.exports = Symbol;
+module.exports = SymbolInspector;

--- a/src/js/components/inspectors/Text.jsx
+++ b/src/js/components/inspectors/Text.jsx
@@ -1,9 +1,9 @@
 'use strict';
 var React = require('react'),
     Property = require('./Property'),
-    Base = require('../../model/primitives/marks/Text');
+    Text = require('../../model/primitives/marks/Text');
 
-var Text = React.createClass({
+var TextInspector = React.createClass({
   render: function() {
     var props = this.props,
         primitive = props.primitive,
@@ -26,7 +26,7 @@ var Text = React.createClass({
         <Property name="font" label="Font"
           primitive={primitive}
           type="select"
-          opts={Base.fonts}
+          opts={Text.fonts}
           canDrop={true}
           scale={update.font.scale}
           field={update.font.field}
@@ -43,7 +43,7 @@ var Text = React.createClass({
         <Property name="fontWeight" label="Weight"
           primitive={primitive}
           type="select"
-          opts={Base.fontWeights}
+          opts={Text.fontWeights}
           canDrop={true}
           scale={update.fontWeight.scale}
           field={update.fontWeight.field}
@@ -52,7 +52,7 @@ var Text = React.createClass({
         <Property name="fontStyle" label="Style"
           primitive={primitive}
           type="select"
-          opts={Base.fontStyles}
+          opts={Text.fontStyles}
           canDrop={true}
           scale={update.fontStyle.scale}
           field={update.fontStyle.field}
@@ -116,7 +116,7 @@ var Text = React.createClass({
         <Property name="align" label="Horizontal"
           primitive={primitive}
           type="select"
-          opts={Base.alignments}
+          opts={Text.alignments}
           canDrop={true}
           scale={update.align.scale}
           field={update.align.field}
@@ -125,7 +125,7 @@ var Text = React.createClass({
         <Property name="baseline" label="Vertical"
           primitive={primitive}
           type="select"
-          opts={Base.baselines}
+          opts={Text.baselines}
           canDrop={true}
           scale={update.baseline.scale}
           field={update.baseline.field}
@@ -143,4 +143,4 @@ var Text = React.createClass({
   }
 });
 
-module.exports = Text;
+module.exports = TextInspector;

--- a/src/js/transforms/manipulators/Area.js
+++ b/src/js/transforms/manipulators/Area.js
@@ -1,6 +1,6 @@
 'use strict';
 var inherits = require('inherits'),
-    Base = require('./Manipulators'),
+    Manipulators = require('./Manipulators'),
     spec = require('../../model/primitives/marks/manipulators'),
     map = require('../../util/map-manipulator'),
     CONST = spec.CONST,
@@ -19,10 +19,10 @@ var inherits = require('inherits'),
  * @constructor
  */
 function AreaManipulators(graph) {
-  return Base.call(this, graph);
+  return Manipulators.call(this, graph);
 }
 
-inherits(AreaManipulators, Base);
+inherits(AreaManipulators, Manipulators);
 
 AreaManipulators.prototype.handles = function(item) {
   var bounds = item.mark.bounds;

--- a/src/js/transforms/manipulators/Line.js
+++ b/src/js/transforms/manipulators/Line.js
@@ -1,6 +1,6 @@
 'use strict';
 var inherits = require('inherits'),
-    Base = require('./Manipulators'),
+    Manipulators = require('./Manipulators'),
     spec = require('../../model/primitives/marks/manipulators'),
     map = require('../../util/map-manipulator'),
     CONST = spec.CONST,
@@ -19,10 +19,10 @@ var inherits = require('inherits'),
  * @constructor
  */
 function LineManipulators(graph) {
-  return Base.call(this, graph);
+  return Manipulators.call(this, graph);
 }
 
-inherits(LineManipulators, Base);
+inherits(LineManipulators, Manipulators);
 
 LineManipulators.prototype.handles = function(item) {
   var bounds = item.mark.bounds;

--- a/src/js/transforms/manipulators/Rect.js
+++ b/src/js/transforms/manipulators/Rect.js
@@ -1,7 +1,7 @@
 'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
-    Base = require('./Manipulators'),
+    Manipulators = require('./Manipulators'),
     spec = require('../../model/primitives/marks/manipulators'),
     map = require('../../util/map-manipulator'),
     CONST = spec.CONST,
@@ -19,10 +19,10 @@ var dl = require('datalib'),
  * @constructor
  */
 function RectManipulators(graph) {
-  return Base.call(this, graph);
+  return Manipulators.call(this, graph);
 }
 
-inherits(RectManipulators, Base);
+inherits(RectManipulators, Manipulators);
 
 RectManipulators.prototype.handles = function(item) {
   var c = spec.coords(item.bounds, 'handle');

--- a/src/js/transforms/manipulators/Symbol.js
+++ b/src/js/transforms/manipulators/Symbol.js
@@ -1,6 +1,6 @@
 'use strict';
 var inherits = require('inherits'),
-    Base = require('./Manipulators'),
+    Manipulators = require('./Manipulators'),
     spec = require('../../model/primitives/marks/manipulators'),
     map = require('../../util/map-manipulator'),
     CONST = spec.CONST,
@@ -16,10 +16,10 @@ var inherits = require('inherits'),
  * @constructor
  */
 function SymbolManipulators(graph) {
-  return Base.call(this, graph);
+  return Manipulators.call(this, graph);
 }
 
-inherits(SymbolManipulators, Base);
+inherits(SymbolManipulators, Manipulators);
 
 SymbolManipulators.prototype.handles = function(item) {
   var c = spec.coords(item.bounds, 'handle');

--- a/src/js/transforms/manipulators/Text.js
+++ b/src/js/transforms/manipulators/Text.js
@@ -1,6 +1,6 @@
 'use strict';
 var inherits = require('inherits'),
-    Base = require('./Manipulators'),
+    Manipulators = require('./Manipulators'),
     spec = require('../../model/primitives/marks/manipulators'),
     map = require('../../util/map-manipulator'),
     CONST = spec.CONST,
@@ -18,10 +18,10 @@ var inherits = require('inherits'),
  * @constructor
  */
 function TextManipulators(graph) {
-  return Base.call(this, graph);
+  return Manipulators.call(this, graph);
 }
 
-inherits(TextManipulators, Base);
+inherits(TextManipulators, Manipulators);
 
 TextManipulators.prototype.handles = function(item) {
   var c = spec.coords(item.bounds, 'handle');


### PR DESCRIPTION
**Description of the problem this pull request fixes**

No functionality changes here; this is the result of my review of the app hierarchy, focusing on clarifying the relationships between components by using less-generic identifiers ("Area" instead of "Base," and "AreaInspector" when we're in a file with the Area Mark _and_ Inspector, e.g.).

Changes proposed in this pull request:
- Rename a bunch of things

**Steps to functionally test this:**
- Does the app break...? it should not.
