### PR TITLE
Add an incrementing counter utility

### DIFF
--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -5,7 +5,7 @@ var dl = require('datalib'),
     sg = require('../signals'),
     model = require('../'),
     lookup = model.lookup,
-    id = 0;
+    counter = require('../../util/counter');
 
 /**
  * @classdesc A Lyra Primitive.
@@ -19,7 +19,8 @@ var dl = require('datalib'),
  * @constructor
  */
 function Primitive() {
-  model.primitive(this._id = ++id, this);
+  this._id = counter.global();
+  model.primitive(this._id, this);
   return this;
 }
 

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -10,7 +10,7 @@ var dl = require('datalib'),
     propSg = require('../../../util/prop-signal'),
     model = require('../../'),
     lookup = model.lookup,
-    count = {group: -1};
+    counter = require('../../../util/counter');
 
 /**
  * @classdesc A Lyra Mark Primitive.
@@ -29,8 +29,7 @@ var dl = require('datalib'),
  * @constructor
  */
 function Mark(type) {
-  count[type] = count[type] || 0;
-  this.name = type + '_' + (++count[type]);
+  this.name = type + '_' + counter.type(type);
   this.type = type;
   this.from = undefined;
 

--- a/src/js/util/counter.js
+++ b/src/js/util/counter.js
@@ -1,10 +1,10 @@
-'use strict';
 /**
  * This module defines methods that can be used to keep a set of discrete,
  * incrementing numeric counters, for use constructing primitive IDs and names.
  *
  * @module util/counter
  */
+'use strict';
 
 // Global counter starts at 1
 var globalCounter = 1;
@@ -18,9 +18,10 @@ var typeCounters = {
  * Get the next value from a globally incrementing counter, useful for generating
  * unique id numbers.
  *
- * @return {number} The next number in the counter
+ * @method global
+ * @returns {number} The next number in the counter
  */
-function global() {
+function getGlobalCounter() {
   return globalCounter++;
 }
 
@@ -28,20 +29,26 @@ function global() {
  * Get the next value from an incrementing counter specific to a particular type
  * of object, useful for creating unique names for marks.
  *
+ * @method type
  * @param {string} type - The type of counter to return, e.g.
- * @return {number} The next number in the counter for the provided type
+ * @returns {number|void} The next number in the counter for the provided type,
+ * or "undefined" (if invoked with an invalid type)
  */
-function type(type) {
+function getTypeCounter(type) {
+
+  /* eslint consistent-return: 0 */
   if (!type) {
     return;
   }
+
   if (typeof typeCounters[type] === 'undefined') {
     typeCounters[type] = 1;
   }
+
   return typeCounters[type]++;
 }
 
 module.exports = {
-  global: global,
-  type: type
+  global: getGlobalCounter,
+  type: getTypeCounter
 };

--- a/src/js/util/counter.js
+++ b/src/js/util/counter.js
@@ -1,0 +1,47 @@
+'use strict';
+/**
+ * This module defines methods that can be used to keep a set of discrete,
+ * incrementing numeric counters, for use constructing primitive IDs and names.
+ *
+ * @module util/counter
+ */
+
+// Global counter starts at 1
+var globalCounter = 1;
+
+// Group starts at 0 so that the scene is group0; other types start at 1
+var typeCounters = {
+  group: 0
+};
+
+/**
+ * Get the next value from a globally incrementing counter, useful for generating
+ * unique id numbers.
+ *
+ * @return {number} The next number in the counter
+ */
+function global() {
+  return globalCounter++;
+}
+
+/**
+ * Get the next value from an incrementing counter specific to a particular type
+ * of object, useful for creating unique names for marks.
+ *
+ * @param {string} type - The type of counter to return, e.g.
+ * @return {number} The next number in the counter for the provided type
+ */
+function type(type) {
+  if (!type) {
+    return;
+  }
+  if (typeof typeCounters[type] === 'undefined') {
+    typeCounters[type] = 1;
+  }
+  return typeCounters[type]++;
+}
+
+module.exports = {
+  global: global,
+  type: type
+};

--- a/src/js/util/counter.test.js
+++ b/src/js/util/counter.test.js
@@ -24,8 +24,8 @@ describe('counter utility', function() {
     });
 
     it('counts up by 1 on each subsequent call', function() {
-      var results = [];
-      for (var i = 0; i < 10; i++) {
+      var results = [], i;
+      for (i = 0; i < 10; i++) {
         results.push(counter.global());
       }
       expect(results).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
@@ -51,8 +51,8 @@ describe('counter utility', function() {
     });
 
     it('counts up by 1 on each subsequent call for groups', function() {
-      var results = [];
-      for (var i = 0; i < 10; i++) {
+      var results = [], i;
+      for (i = 0; i < 10; i++) {
         results.push(counter.type('group'));
       }
       expect(results).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -64,16 +64,17 @@ describe('counter utility', function() {
     });
 
     it('counts up by 1 on each subsequent call for a given type', function() {
-      var groupResults = [];
-      var rectResults = [];
-      var scaleResults = [];
-      for (var i = 0; i < 10; i++) {
+      var groupResults = [],
+          rectResults = [],
+          scaleResults = [],
+          i;
+      for (i = 0; i < 10; i++) {
         groupResults.push(counter.type('group'));
       }
-      for (var i = 0; i < 5; i++) {
+      for (i = 0; i < 5; i++) {
         rectResults.push(counter.type('rect'));
       }
-      for (var i = 0; i < 7; i++) {
+      for (i = 0; i < 7; i++) {
         scaleResults.push(counter.type('scale'));
       }
       expect(groupResults).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/src/js/util/counter.test.js
+++ b/src/js/util/counter.test.js
@@ -1,0 +1,91 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+var expect = require('chai').expect;
+
+describe('counter utility', function() {
+  var counter;
+
+  beforeEach(function() {
+    // Pull in a fresh module so that its internal counter caches are reset
+    +delete require.cache[require.resolve('./counter')];
+    counter = require('./counter');
+  });
+
+  describe('.global() counter', function() {
+
+    it('is a function', function() {
+      expect(counter).to.have.property('global');
+      expect(counter.global).to.be.a('function');
+    });
+
+    it('starts at 1', function() {
+      var next = counter.global();
+      expect(next).to.equal(1);
+    });
+
+    it('counts up by 1 on each subsequent call', function() {
+      var results = [];
+      for (var i = 0; i < 10; i++) {
+        results.push(counter.global());
+      }
+      expect(results).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+  });
+
+  describe('.type() counter', function() {
+
+    it('is a function', function() {
+      expect(counter).to.have.property('type');
+      expect(counter.type).to.be.a('function');
+    });
+
+    it('returns undefined if no type is provided', function() {
+      var next = counter.type();
+      expect(next).not.to.be.defined;
+    });
+
+    it('starts groups at 0', function() {
+      var next = counter.type('group');
+      expect(next).to.equal(0);
+    });
+
+    it('counts up by 1 on each subsequent call for groups', function() {
+      var results = [];
+      for (var i = 0; i < 10; i++) {
+        results.push(counter.type('group'));
+      }
+      expect(results).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('starts other marks at 1', function() {
+      var next = counter.type('rect');
+      expect(next).to.equal(1);
+    });
+
+    it('counts up by 1 on each subsequent call for a given type', function() {
+      var groupResults = [];
+      var rectResults = [];
+      var scaleResults = [];
+      for (var i = 0; i < 10; i++) {
+        groupResults.push(counter.type('group'));
+      }
+      for (var i = 0; i < 5; i++) {
+        rectResults.push(counter.type('rect'));
+      }
+      for (var i = 0; i < 7; i++) {
+        scaleResults.push(counter.type('scale'));
+      }
+      expect(groupResults).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(counter.type('group')).to.equal(10);
+
+      expect(rectResults).to.deep.equal([1, 2, 3, 4, 5]);
+      expect(counter.type('rect')).to.equal(6);
+
+      expect(scaleResults).to.deep.equal([1, 2, 3, 4, 5, 6, 7]);
+      expect(counter.type('scale')).to.equal(8);
+    });
+
+  });
+
+});


### PR DESCRIPTION
**Description of the problem this pull request fixes**

There are a lot of implicit incrementing counters in Lyra: this makes them explicit and tested. As we move on to a world where we can load state from a file or localstorage or some such, we will need to add in the ability to seed these counters at a base starting value for each type; making a utility sets us up to make that change as well.

Changes proposed in this pull request:
- Implement an incrementing counter utility
- Utilize that utility within mark and primitive code

**This PR includes:**
- [x] Tests
- [x] functional comments
- [x] high level description of any new components

**Steps to functionally test this:**
- Smoke test
- Unit tests pass
