### PR TITLE
Permit mark properties to be passed in on creation

### DIFF
--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -19,9 +19,8 @@ var dl = require('datalib'),
  * @constructor
  */
 function Primitive() {
-  this._id = counter.global();
+  this._id = this._id || counter.global();
   model.primitive(this._id, this);
-  return this;
 }
 
 function _clean(spec, clean) {

--- a/src/js/model/primitives/marks/Area.js
+++ b/src/js/model/primitives/marks/Area.js
@@ -1,6 +1,5 @@
 'use strict';
-var dl = require('datalib'),
-    inherits = require('inherits'),
+var inherits = require('inherits'),
     sg = require('../../../model/signals'),
     Mark = require('./Mark'),
     anchorTarget = require('../../../util/anchor-target'),
@@ -17,13 +16,33 @@ var DELTA = sg.DELTA,
  * @extends {Mark}
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'area')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Area() {
-  Mark.call(this, {
+function Area(props) {
+  Mark.call(this, props || Area.defaultProperties());
+}
+
+// inherit Mark class' prototype
+inherits(Area, Mark);
+
+/**
+ * Returns an object representing the default values for an area mark,
+ * containing a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Area.defaultProperties = function() {
+  return {
     type: 'area',
-    properties: {
+    // name: 'area' + '_' + counter.type('area'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
       update: {
-        // Defaults
         x2: {value: 0},
         y2: {value: 0},
         xc: {value: 60, _disabled: true},
@@ -36,15 +55,9 @@ function Area() {
         width: {value: 30, _disabled: true},
         height: {value: 30, _disabled: true}
       }
-    }
-  });
-
-  return this;
-}
-
-// inherit Mark class' prototype
-inherits(Area, Mark);
-
+    })
+  };
+};
 
 Area.prototype.initHandles = function() {
   var at = anchorTarget.bind(null, this, 'handles'),

--- a/src/js/model/primitives/marks/Area.js
+++ b/src/js/model/primitives/marks/Area.js
@@ -19,11 +19,11 @@ var DELTA = sg.DELTA,
  * @constructor
  */
 function Area() {
-  Mark.call(this, 'area');
-
-  var props = this.properties,
-      update = props.update,
-      defaults = {
+  Mark.call(this, {
+    type: 'area',
+    properties: {
+      update: {
+        // Defaults
         x2: {value: 0},
         y2: {value: 0},
         xc: {value: 60, _disabled: true},
@@ -35,8 +35,9 @@ function Area() {
         orient: {value: 'vertical'},
         width: {value: 30, _disabled: true},
         height: {value: 30, _disabled: true}
-      };
-  dl.extend(update, defaults);
+      }
+    }
+  });
 
   return this;
 }

--- a/src/js/model/primitives/marks/Area.test.js
+++ b/src/js/model/primitives/marks/Area.test.js
@@ -1,17 +1,54 @@
 /* eslint no-unused-expressions:0 */
 'use strict';
 var expect = require('chai').expect;
-var assert = require('chai').assert;
 var Area = require('./Area');
 var Mark = require('./Mark');
+var VLSingle = require('../../rules/VLSingle');
 
 describe('Area Mark Primitive', function() {
   var area;
-  beforeEach(function() {
-    area = new Area();
+
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Area).to.have.property('defaultProperties');
+      expect(Area.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Area.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'area',
+        properties: {
+          update: {
+            x: {value: 25},
+            y: {value: 25},
+            fillOpacity: {value: 1},
+            strokeWidth: {value: 0.25},
+            x2: {value: 0},
+            y2: {value: 0},
+            xc: {value: 60, _disabled: true},
+            yc: {value: 60, _disabled: true},
+            tension: {value: 13},
+            interpolate: {value: 'monotone'},
+            fill: {value: '#55498D'},
+            stroke: {value: '#55498D'},
+            orient: {value: 'vertical'},
+            width: {value: 30, _disabled: true},
+            height: {value: 30, _disabled: true}
+          }
+        }
+      });
+    });
+
   });
 
   describe('constructor', function() {
+
+    beforeEach(function() {
+      area = new Area();
+    });
+
     it('is a constructor function', function() {
       expect(Area).to.be.a('function');
     });
@@ -23,47 +60,102 @@ describe('Area Mark Primitive', function() {
     it('inherits from Mark', function() {
       expect(area).to.be.an.instanceOf(Mark);
     });
+
+    it('initializes instance with a .type property of "area"', function() {
+      expect(area).to.have.property('type');
+      expect(area.type).to.be.a('string');
+      expect(area.type).to.equal('area');
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(area).to.have.property('name');
+      expect(area.name).to.be.a('string');
+      expect(area.name.startsWith('area_')).to.be.true;
+    });
+
+    it('initializes instance with default vega properties', function() {
+      var defaults = Area.defaultProperties().properties;
+      expect(area).to.have.property('properties');
+      expect(area.properties).to.be.an('object');
+      expect(area.properties).to.deep.equal(defaults);
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(area).to.have.property('_id');
+      expect(area._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(area.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(area).to.have.property('_rule');
+      expect(area._rule).to.be.an('object');
+      expect(area._rule).to.be.an.instanceOf(VLSingle);
+    });
   });
 
-  describe('default properties', function() {
+  describe('constructor with non-default properties', function() {
 
-    it('is initialized with stroke', function() {
-      var stroke = {value: '#55498D'};
-      expect(area.properties.update).to.have.property('stroke');
-      assert.deepEqual(area.properties.update.stroke, stroke);
+    beforeEach(function() {
+      area = new Area({
+        type: 'area',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            fill: '#ff000'
+          }
+        }
+      });
     });
 
-    it('is initialized with fill', function() {
-      var fill = {value: '#55498D'};
-      expect(area.properties.update).to.have.property('fill');
-      assert.deepEqual(area.properties.update.fill, fill);
+    it('initializes instance with the name from the provided props object', function() {
+      expect(area).to.have.property('name');
+      expect(area.name).to.be.a('string');
+      expect(area.name).to.equal('Spartacus');
     });
 
-    it('is initialized with interpolate', function() {
-      var interpolate = {value: 'monotone'};
-      expect(area.properties.update).to.have.property('interpolate');
-      assert.deepEqual(area.properties.update.interpolate, interpolate);
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(area).to.have.property('_id');
+      expect(area._id).to.be.a('number');
+      expect(area._id).to.equal(2501);
     });
 
-    it('is initialized with orient', function() {
-      var orient = {value: 'vertical'};
-      expect(area.properties.update).to.have.property('orient');
-      assert.deepEqual(area.properties.update.orient, orient);
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(area).to.have.property('properties');
+      expect(area.properties).to.deep.equal({
+        update: {
+          fill: '#ff000'
+        }
+      });
     });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(area).to.have.property('_rule');
+      expect(area._rule).to.be.an('object');
+      expect(area._rule).to.be.an.instanceOf(VLSingle);
+    });
+
   });
-
 
   describe('export method', function() {
+
+    beforeEach(function() {
+      area = new Area();
+    });
 
     it('areas initialized w/ dummy data', function() {
       var exported = area.export(false);
       expect(exported).to.have.property('from');
-      assert.deepEqual(exported.from, {data: 'dummy_data_area'});
+      expect(exported.from).to.deep.equal({data: 'dummy_data_area'});
     });
 
   });
 
   describe('static property options lists', function() {
+
     it('exposes a static property defining interpolate options', function() {
       expect(Area).to.have.property('INTERPOLATE');
       var interpolate = [
@@ -78,10 +170,12 @@ describe('Area Mark Primitive', function() {
       ];
       expect(Area.INTERPOLATE).to.deep.equal(interpolate);
     });
+
     it('exposes a static property defining orient options', function() {
       expect(Area).to.have.property('ORIENT');
       expect(Area.ORIENT).to.deep.equal(['horizontal', 'vertical']);
     });
+
   });
 
 });

--- a/src/js/model/primitives/marks/Group.js
+++ b/src/js/model/primitives/marks/Group.js
@@ -10,42 +10,9 @@ var dl = require('datalib'),
     ns = require('../../../util/ns');
 
 var CHILD_TYPES = ['scales', 'axes', 'legends', 'marks'];
-// MARK_TYPES = ['group', 'rect', 'symbol', 'arc', 'area', 'line', 'text'];
-
-/**
- * @classdesc A Lyra Group Mark Primitive.
- * @extends {Mark}
- * @see  Vega's {@link https://github.com/vega/vega/wiki/Group-Marks|Group Marks}
- * documentation for more information on this class' "public" properties.
- *
- * @constructor
- */
-function Group() {
-  Mark.call(this, {
-    type: 'group',
-    properties: {
-      // By default, make groups full width/height.
-      update: {
-        x: {value: 0},
-        y: {value: 0},
-        width: {signal: ns('vis_width')},
-        height: {signal: ns('vis_height')},
-        fill: {value: 'transparent'}
-      }
-    }
-  });
-
-  this.scales = [];
-  this.legends = [];
-  this.axes = [];
-  this.marks = [];
-
-  return this;
-}
-
-
+// var MARK_TYPES = ['group', 'rect', 'symbol', 'arc', 'area', 'line', 'text'];
 var CHILDREN = {
-  group: Group,
+  // group: Group, // Assigned below
   rect: require('./Rect'),
   symbol: require('./Symbol'),
   text: require('./Text'),
@@ -56,8 +23,55 @@ var CHILDREN = {
   area: require('./Area')
 };
 
+/**
+ * @classdesc A Lyra Group Mark Primitive.
+ * @extends {Mark}
+ * @see  Vega's {@link https://github.com/vega/vega/wiki/Group-Marks|Group Marks}
+ * documentation for more information on this class' "public" properties.
+ *
+ * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'group')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
+ */
+function Group(props) {
+  Mark.call(this, props || Group.defaultProperties());
+}
+
+CHILDREN.group = Group;
 
 inherits(Group, Mark);
+
+/**
+ * Returns an object representing the default values for a group mark,
+ * containing a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Group.defaultProperties = function() {
+  return {
+    type: 'group',
+    // name: 'group' + '_' + counter.type('group'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
+      update: {
+        x: {value: 0},
+        y: {value: 0},
+        width: {signal: ns('vis_width')},
+        height: {signal: ns('vis_height')},
+        fill: {value: 'transparent'}
+      }
+    }),
+    // Containers for child marks
+    scales: [],
+    legends: [],
+    axes: [],
+    marks: []
+  };
+};
 
 Group.prototype.export = function(resolve) {
   var self = this,

--- a/src/js/model/primitives/marks/Group.js
+++ b/src/js/model/primitives/marks/Group.js
@@ -21,21 +21,24 @@ var CHILD_TYPES = ['scales', 'axes', 'legends', 'marks'];
  * @constructor
  */
 function Group() {
-  Mark.call(this, 'group');
+  Mark.call(this, {
+    type: 'group',
+    properties: {
+      // By default, make groups full width/height.
+      update: {
+        x: {value: 0},
+        y: {value: 0},
+        width: {signal: ns('vis_width')},
+        height: {signal: ns('vis_height')},
+        fill: {value: 'transparent'}
+      }
+    }
+  });
 
   this.scales = [];
   this.legends = [];
   this.axes = [];
   this.marks = [];
-
-  // By default, make groups full width/height.
-  this.properties.update = {
-    x: {value: 0},
-    y: {value: 0},
-    width: {signal: ns('vis_width')},
-    height: {signal: ns('vis_height')},
-    fill: {value: 'transparent'}
-  };
 
   return this;
 }

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -5,15 +5,49 @@ var expect = require('chai').expect;
 
 var Group = require('./Group');
 var Mark = require('./Mark');
+var ns = require('../../../util/ns');
+var VLSingle = require('../../rules/VLSingle');
 
 describe('Group Mark', function() {
   var group;
 
-  beforeEach(function() {
-    group = new Group();
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Group).to.have.property('defaultProperties');
+      expect(Group.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Group.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'group',
+        properties: {
+          update: {
+            fillOpacity: {value: 1},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 0.25},
+            x: {value: 0},
+            y: {value: 0},
+            width: {signal: ns('vis_width')},
+            height: {signal: ns('vis_height')},
+            fill: {value: 'transparent'}
+          }
+        },
+        scales: [],
+        legends: [],
+        axes: [],
+        marks: []
+      });
+    });
+
   });
 
   describe('constructor', function() {
+
+    beforeEach(function() {
+      group = new Group();
+    });
 
     it('is a constructor function', function() {
       expect(Group).to.be.a('function');
@@ -27,37 +61,122 @@ describe('Group Mark', function() {
       expect(group).to.be.an.instanceOf(Mark);
     });
 
-  });
-
-  describe('default properties', function() {
-
-    it('contains a properties object', function() {
+    it('initializes instance with default vega properties', function() {
+      var defaults = Group.defaultProperties().properties;
       expect(group).to.have.property('properties');
+      expect(group.properties).to.be.an('object');
+      expect(group.properties).to.deep.equal(defaults);
     });
 
-    it('is initialized with a scales array', function() {
+    it('initializes instance with a scales array', function() {
       expect(group).to.have.property('scales');
       expect(group.scales).to.deep.equal([]);
     });
 
-    it('is initialized with a legends array', function() {
+    it('initializes instance with a legends array', function() {
       expect(group).to.have.property('legends');
       expect(group.legends).to.deep.equal([]);
     });
 
-    it('is initialized with a axes array', function() {
+    it('initializes instance with a axes array', function() {
       expect(group).to.have.property('axes');
       expect(group.axes).to.deep.equal([]);
     });
 
-    it('is initialized with a marks array', function() {
+    it('initializes instance with a marks array', function() {
       expect(group).to.have.property('marks');
       expect(group.marks).to.deep.equal([]);
+    });
+
+    it('initializes instance with a .type property of "group"', function() {
+      expect(group).to.have.property('type');
+      expect(group.type).to.be.a('string');
+      expect(group.type).to.equal('group');
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(group).to.have.property('name');
+      expect(group.name).to.be.a('string');
+      expect(group.name.startsWith('group_')).to.be.true;
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(group).to.have.property('_id');
+      expect(group._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(group.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(group).to.have.property('_rule');
+      expect(group._rule).to.be.an('object');
+      expect(group._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      group = new Group({
+        type: 'group',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            fill: '#ff000'
+          }
+        },
+        scales: [72, 91],
+        legends: [],
+        axes: [361],
+        marks: [1, 2, 3, 5, 8, 13, 21, 34]
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(group).to.have.property('name');
+      expect(group.name).to.be.a('string');
+      expect(group.name).to.equal('Spartacus');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(group).to.have.property('_id');
+      expect(group._id).to.be.a('number');
+      expect(group._id).to.equal(2501);
+    });
+
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(group).to.have.property('properties');
+      expect(group.properties).to.deep.equal({
+        update: {
+          fill: '#ff000'
+        }
+      });
+    });
+
+    it('initializes instance with the child collections from the provided properties', function() {
+      expect(group.scales).to.deep.equal([72, 91]);
+      expect(group.legends).to.deep.equal([]);
+      expect(group.axes).to.deep.equal([361]);
+      expect(group.marks).to.deep.equal([1, 2, 3, 5, 8, 13, 21, 34]);
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(group).to.have.property('_rule');
+      expect(group._rule).to.be.an('object');
+      expect(group._rule).to.be.an.instanceOf(VLSingle);
     });
 
   });
 
   describe('child method', function() {
+
+    beforeEach(function() {
+      group = new Group();
+    });
 
     it('is a function', function() {
       expect(group).to.have.property('child');

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -195,11 +195,9 @@ describe('Group Mark', function() {
         expect(child).to.be.an('object');
         expect(child.parent()).to.equal(group);
       });
-    });
-
-    it('creates a scale but does not assign itself as parent', function() {
-      var scale = group.child('scales');
-      expect(scale.parent).to.be.null;
+      expect(group.marks.length).to.equal(3);
+      expect(group.axes.length).to.equal(1);
+      expect(group.legends.length).to.equal(1);
     });
 
     it('throws an error if provided an invalid type', function() {

--- a/src/js/model/primitives/marks/Line.js
+++ b/src/js/model/primitives/marks/Line.js
@@ -1,6 +1,5 @@
 'use strict';
-var dl = require('datalib'),
-    inherits = require('inherits'),
+var inherits = require('inherits'),
     sg = require('../../../model/signals'),
     Mark = require('./Mark'),
     anchorTarget = require('../../../util/anchor-target'),
@@ -17,24 +16,43 @@ var DELTA = sg.DELTA,
  * @extends {Mark}
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'line')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Line() {
-  Mark.call(this, {
-    type: 'line',
-    properties: {
-      // Defaults
-      update: {
-        stroke: {value: '#000000'},
-        strokeWidth: {value: 3}
-      }
-    }
-  });
-
-  return this;
+function Line(props) {
+  Mark.call(this, props || Line.defaultProperties());
 }
 
 // inherit Mark class' prototype
 inherits(Line, Mark);
+
+/**
+ * Returns an object representing the default values for a rect mark, containing
+ * a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Line.defaultProperties = function() {
+  var defaults = {
+    type: 'line',
+    // name: 'line' + '_' + counter.type('line'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
+      update: {
+        stroke: {value: '#000000'},
+        strokeWidth: {value: 3}
+      }
+    })
+  };
+  // Mark gives us two defaults we do not want
+  delete defaults.properties.update.fill;
+  delete defaults.properties.update.fillOpacity;
+  return defaults;
+};
 
 Line.prototype.initHandles = function() {
   var at = anchorTarget.bind(null, this, 'handles'),
@@ -64,9 +82,6 @@ Line.prototype.export = function(resolve) {
       field: 'bar'
     };
   }
-
-  delete spec.properties.update.fill;
-  delete spec.properties.update.fillOpacity;
 
   return spec;
 };

--- a/src/js/model/primitives/marks/Line.js
+++ b/src/js/model/primitives/marks/Line.js
@@ -19,16 +19,16 @@ var DELTA = sg.DELTA,
  * @constructor
  */
 function Line() {
-  Mark.call(this, 'line');
-
-  var props = this.properties,
-      update = props.update,
-      defaults = {
+  Mark.call(this, {
+    type: 'line',
+    properties: {
+      // Defaults
+      update: {
         stroke: {value: '#000000'},
         strokeWidth: {value: 3}
-      };
-
-  dl.extend(update, defaults);
+      }
+    }
+  });
 
   return this;
 }

--- a/src/js/model/primitives/marks/Line.test.js
+++ b/src/js/model/primitives/marks/Line.test.js
@@ -1,53 +1,148 @@
 /* eslint no-unused-expressions:0 */
 'use strict';
 var expect = require('chai').expect;
-var assert = require('chai').assert;
+
 var Line = require('./Line');
 var Mark = require('./Mark');
+var VLSingle = require('../../rules/VLSingle');
 
 describe('Line Mark Primitive', function() {
   var line;
-  beforeEach(function() {
-    line = new Line();
+
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Line).to.have.property('defaultProperties');
+      expect(Line.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Line.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'line',
+        properties: {
+          update: {
+            x: {value: 25},
+            y: {value: 25},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 3}
+          }
+        }
+      });
+    });
+
   });
 
   describe('constructor', function() {
+
+    beforeEach(function() {
+      line = new Line();
+    });
+
     it('is a constructor function', function() {
       expect(Line).to.be.a('function');
     });
 
-    it('may be used to create group instances', function() {
+    it('may be used to create line instances', function() {
       expect(line).to.be.an.instanceOf(Line);
     });
 
     it('inherits from Mark', function() {
       expect(line).to.be.an.instanceOf(Mark);
     });
-  });
 
-  describe('default properties', function() {
-
-    it('is initialized with stroke', function() {
-      var stroke = {value: '#000000'};
-      expect(line.properties.update).to.have.property('stroke');
-      assert.deepEqual(line.properties.update.stroke, stroke);
+    it('initializes instance with a .type property of "line"', function() {
+      expect(line).to.have.property('type');
+      expect(line.type).to.be.a('string');
+      expect(line.type).to.equal('line');
     });
 
-    it('is initialized with strokeWidth', function() {
-      var strokeWidth = {value: 3};
-      expect(line.properties.update).to.have.property('strokeWidth');
-      assert.deepEqual(line.properties.update.strokeWidth, strokeWidth);
+    it('initializes instance with an appropriate .name property', function() {
+      expect(line).to.have.property('name');
+      expect(line.name).to.be.a('string');
+      expect(line.name.startsWith('line_')).to.be.true;
+    });
+
+    it('initializes instance with default vega properties', function() {
+      expect(line).to.have.property('properties');
+      expect(line.properties).to.be.an('object');
+      expect(line.properties).to.deep.equal({
+        update: {
+          x: {value: 25},
+          y: {value: 25},
+          stroke: {value: '#000000'},
+          strokeWidth: {value: 3}
+        }
+      });
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(line).to.have.property('_id');
+      expect(line._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(line.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(line).to.have.property('_rule');
+      expect(line._rule).to.be.an('object');
+      expect(line._rule).to.be.an.instanceOf(VLSingle);
     });
 
   });
 
+  describe('constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      line = new Line({
+        type: 'line',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            stroke: '#010101'
+          }
+        }
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(line).to.have.property('name');
+      expect(line.name).to.be.a('string');
+      expect(line.name).to.equal('Spartacus');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(line).to.have.property('_id');
+      expect(line._id).to.be.a('number');
+      expect(line._id).to.equal(2501);
+    });
+
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(line).to.have.property('properties');
+      expect(line.properties).to.deep.equal({
+        update: {
+          stroke: '#010101'
+        }
+      });
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(line).to.have.property('_rule');
+      expect(line._rule).to.be.an('object');
+      expect(line._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
 
   describe('export method', function() {
 
     it('lines initialized w/ dummy data', function() {
       var exported = line.export(false);
       expect(exported).to.have.property('from');
-      assert.deepEqual(exported.from, {data: 'dummy_data_line'});
+      expect(exported.from).to.deep.equal({data: 'dummy_data_line'});
     });
 
     it('lines spec does not have fill property', function() {

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -27,22 +27,38 @@ var dl = require('datalib'),
  * documentation for more information on this class' "public" properties.
  *
  * @constructor
+ * @param {Object} config - Configuration options
+ * @param {string} config.type - The type of mark, e.g. "rect"
+ * @param {name}   [config.name] - The name of the mark (set based on type
+ * if not provided in config object)
+ * @param {Object} [config.properties] - Mark properties object (initialized
+ * to reasonable defaults if not provided in config object)
  */
-function Mark(type) {
+function Mark(config) {
+  var type = config.type;
+  this.type = type;
   this.name = type + '_' + counter.type(type);
   this.type = type;
   this.from = undefined;
 
-  this.properties = {
-    update: {
-      x: {value: 25},
-      y: {value: 25},
-      fill: {value: '#4682b4'},
-      fillOpacity: {value: 1},
-      stroke: {value: '#000000'},
-      strokeWidth: {value: 0.25}
-    }
+  var updateDefault = {
+    x: {value: 25},
+    y: {value: 25},
+    fill: {value: '#4682b4'},
+    fillOpacity: {value: 1},
+    stroke: {value: '#000000'},
+    strokeWidth: {value: 0.25}
   };
+
+  // Pick up any passed-in properties from the provided configuration
+  this.properties = dl.extend({
+    update: {}
+  }, config.properties);
+
+  // dl.extend does not operate as a deep extender, so call it again for
+  // the .update property specifically to ensure any properties passed in
+  // via the configuration argument get set correctly
+  this.properties.update = dl.extend(updateDefault, config.properties.update);
 
   this._rule = new rules.VLSingle(type);
 

--- a/src/js/model/primitives/marks/Rect.js
+++ b/src/js/model/primitives/marks/Rect.js
@@ -1,6 +1,5 @@
 'use strict';
-var dl = require('datalib'),
-    inherits = require('inherits'),
+var inherits = require('inherits'),
     sg = require('../../../model/signals'),
     Mark = require('./Mark'),
     anchorTarget = require('../../../util/anchor-target'),
@@ -16,12 +15,31 @@ var DELTA = sg.DELTA,
  * @extends {Mark}
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'rect')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Rect() {
-  Mark.call(this, {
+function Rect(props) {
+  Mark.call(this, props || Rect.defaultProperties());
+}
+
+inherits(Rect, Mark);
+
+/**
+ * Returns an object representing the default values for a rect mark, containing
+ * a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Rect.defaultProperties = function() {
+  return {
     type: 'rect',
-    properties: {
-      // defaults
+    // name: 'rect' + '_' + counter.type('rect'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
       update: {
         x2: {value: 60},
         y2: {value: 60},
@@ -30,13 +48,9 @@ function Rect() {
         width: {value: 30, _disabled: true},
         height: {value: 30, _disabled: true}
       }
-    }
-  });
-
-  return this;
-}
-
-inherits(Rect, Mark);
+    })
+  };
+};
 
 Rect.prototype.initHandles = function() {
   var at = anchorTarget.bind(null, this, 'handles'),

--- a/src/js/model/primitives/marks/Rect.js
+++ b/src/js/model/primitives/marks/Rect.js
@@ -18,18 +18,19 @@ var DELTA = sg.DELTA,
  * @constructor
  */
 function Rect() {
-  Mark.call(this, 'rect');
-
-  var props = this.properties,
-      update = props.update;
-
-  dl.extend(update, {
-    x2: {value: 60},
-    y2: {value: 60},
-    xc: {value: 60, _disabled: true},
-    yc: {value: 60, _disabled: true},
-    width: {value: 30, _disabled: true},
-    height: {value: 30, _disabled: true}
+  Mark.call(this, {
+    type: 'rect',
+    properties: {
+      // defaults
+      update: {
+        x2: {value: 60},
+        y2: {value: 60},
+        xc: {value: 60, _disabled: true},
+        yc: {value: 60, _disabled: true},
+        width: {value: 30, _disabled: true},
+        height: {value: 30, _disabled: true}
+      }
+    }
   });
 
   return this;

--- a/src/js/model/primitives/marks/Rect.test.js
+++ b/src/js/model/primitives/marks/Rect.test.js
@@ -1,0 +1,155 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+var expect = require('chai').expect;
+var assert = require('chai').assert;
+var Rect = require('./Rect');
+var Mark = require('./Mark');
+var VLSingle = require('../../rules/VLSingle');
+
+describe('Rect Mark Primitive', function() {
+  var rect;
+
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Rect).to.have.property('defaultProperties');
+      expect(Rect.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Rect.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'rect',
+        properties: {
+          update: {
+            x: {value: 25},
+            y: {value: 25},
+            x2: {value: 60},
+            y2: {value: 60},
+            xc: {value: 60, _disabled: true},
+            yc: {value: 60, _disabled: true},
+            width: {value: 30, _disabled: true},
+            height: {value: 30, _disabled: true},
+            fill: {value: '#4682b4'},
+            fillOpacity: {value: 1},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 0.25}
+          }
+        }
+      });
+    });
+
+  });
+
+  describe('constructor', function() {
+
+    beforeEach(function() {
+      rect = new Rect();
+    });
+
+    it('is a constructor function', function() {
+      expect(Rect).to.be.a('function');
+    });
+
+    it('may be used to create rect instances', function() {
+      expect(rect).to.be.an.instanceOf(Rect);
+    });
+
+    it('inherits from Mark', function() {
+      expect(rect).to.be.an.instanceOf(Mark);
+    });
+
+    it('initializes instance with a .type property of "rect"', function() {
+      expect(rect).to.have.property('type');
+      expect(rect.type).to.be.a('string');
+      expect(rect.type).to.equal('rect');
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(rect).to.have.property('name');
+      expect(rect.name).to.be.a('string');
+      expect(rect.name.startsWith('rect_')).to.be.true;
+    });
+
+    it('initializes instance with default vega properties', function() {
+      expect(rect).to.have.property('properties');
+      expect(rect.properties).to.be.an('object');
+      expect(rect.properties).to.deep.equal({
+        update: {
+          x: {value: 25},
+          y: {value: 25},
+          x2: {value: 60},
+          y2: {value: 60},
+          xc: {value: 60, _disabled: true},
+          yc: {value: 60, _disabled: true},
+          width: {value: 30, _disabled: true},
+          height: {value: 30, _disabled: true},
+          fill: {value: '#4682b4'},
+          fillOpacity: {value: 1},
+          stroke: {value: '#000000'},
+          strokeWidth: {value: 0.25}
+        }
+      });
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(rect).to.have.property('_id');
+      expect(rect._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(rect.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(rect).to.have.property('_rule');
+      expect(rect._rule).to.be.an('object');
+      expect(rect._rule).to.be.an.instanceOf(VLSingle);
+    });
+  });
+
+  describe('constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      rect = new Rect({
+        type: 'rect',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            fill: '#ff000'
+          }
+        }
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(rect).to.have.property('name');
+      expect(rect.name).to.be.a('string');
+      expect(rect.name).to.equal('Spartacus');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(rect).to.have.property('_id');
+      expect(rect._id).to.be.a('number');
+      expect(rect._id).to.equal(2501);
+    });
+
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(rect).to.have.property('properties');
+      expect(rect.properties).to.deep.equal({
+        update: {
+          fill: '#ff000'
+        }
+      });
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(rect).to.have.property('_rule');
+      expect(rect._rule).to.be.an('object');
+      expect(rect._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+});

--- a/src/js/model/primitives/marks/Rect.test.js
+++ b/src/js/model/primitives/marks/Rect.test.js
@@ -1,7 +1,6 @@
 /* eslint no-unused-expressions:0 */
 'use strict';
 var expect = require('chai').expect;
-var assert = require('chai').assert;
 var Rect = require('./Rect');
 var Mark = require('./Mark');
 var VLSingle = require('../../rules/VLSingle');

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -3,7 +3,8 @@ var inherits = require('inherits'),
     sg = require('../../signals'),
     Group = require('./Group');
 
-var SG_WIDTH = 'vis_width', SG_HEIGHT = 'vis_height';
+var SG_WIDTH = 'vis_width',
+    SG_HEIGHT = 'vis_height';
 
 /**
  * @classdesc A Lyra Scene Primitive.
@@ -15,20 +16,49 @@ var SG_WIDTH = 'vis_width', SG_HEIGHT = 'vis_height';
  * properties.
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Scene() {
-  Group.call(this);
-  this.width = 610;
-  this.height = 610;
-  this.padding = 'auto';
-  this.background = 'white';
-
-  return this;
+function Scene(props) {
+  Group.call(this, props || Scene.defaultProperties());
 }
 
-
 inherits(Scene, Group);
+// The scene is the top level of hierarchy
 Scene.prototype.parent = null;
+
+/**
+ * Returns an object representing the default values for a scene mark,
+ * containing a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Scene.defaultProperties = function() {
+  // Note that scene has no "properties" property
+  return {
+    // Containers for child marks
+    scales: [],
+    legends: [],
+    axes: [],
+    marks: [],
+    // type will be removed later on, but is used to generate an appropriate name
+    type: 'group',
+    // Scene has no Vega properties object, but we mock it for now to avoid
+    // distrupting the export functionality
+    properties: {
+      update: {}
+    },
+    // Scene-specific visual properties
+    width: 610,
+    height: 610,
+    padding: 'auto',
+    background: 'white'
+    // name: 'group' + '_' + counter.type('group'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+  };
+};
 
 Scene.prototype.init = function() {
   sg.init(SG_WIDTH, this.width);

--- a/src/js/model/primitives/marks/Scene.test.js
+++ b/src/js/model/primitives/marks/Scene.test.js
@@ -6,7 +6,6 @@ var expect = require('chai').expect;
 var Scene = require('./Scene');
 var Group = require('./Group');
 var Mark = require('./Mark');
-var ns = require('../../../util/ns');
 var VLSingle = require('../../rules/VLSingle');
 
 describe('Scene Mark', function() {

--- a/src/js/model/primitives/marks/Scene.test.js
+++ b/src/js/model/primitives/marks/Scene.test.js
@@ -1,0 +1,212 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+
+var expect = require('chai').expect;
+
+var Scene = require('./Scene');
+var Group = require('./Group');
+var Mark = require('./Mark');
+var ns = require('../../../util/ns');
+var VLSingle = require('../../rules/VLSingle');
+
+describe('Scene Mark', function() {
+  var scene;
+
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Scene).to.have.property('defaultProperties');
+      expect(Scene.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Scene.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'group',
+        properties: {
+          update: {}
+        },
+        width: 610,
+        height: 610,
+        padding: 'auto',
+        background: 'white',
+        scales: [],
+        legends: [],
+        axes: [],
+        marks: []
+      });
+    });
+
+  });
+
+  describe('constructor', function() {
+
+    beforeEach(function() {
+      scene = new Scene();
+    });
+
+    it('is a constructor function', function() {
+      expect(Scene).to.be.a('function');
+    });
+
+    it('may be used to create scene instances', function() {
+      expect(scene).to.be.an.instanceOf(Scene);
+    });
+
+    it('inherits from Group', function() {
+      expect(scene).to.be.an.instanceOf(Group);
+    });
+
+    it('inherits from Mark', function() {
+      expect(scene).to.be.an.instanceOf(Mark);
+    });
+
+    it('initializes instance with default presentational properties', function() {
+      expect(scene).to.have.property('width');
+      expect(scene.width).to.equal(610);
+      expect(scene).to.have.property('height');
+      expect(scene.height).to.equal(610);
+      expect(scene).to.have.property('padding');
+      expect(scene.padding).to.equal('auto');
+      expect(scene).to.have.property('background');
+      expect(scene.background).to.equal('white');
+    });
+
+    it('initializes instance with a scales array', function() {
+      expect(scene).to.have.property('scales');
+      expect(scene.scales).to.deep.equal([]);
+    });
+
+    it('initializes instance with a legends array', function() {
+      expect(scene).to.have.property('legends');
+      expect(scene.legends).to.deep.equal([]);
+    });
+
+    it('initializes instance with a axes array', function() {
+      expect(scene).to.have.property('axes');
+      expect(scene.axes).to.deep.equal([]);
+    });
+
+    it('initializes instance with a marks array', function() {
+      expect(scene).to.have.property('marks');
+      expect(scene.marks).to.deep.equal([]);
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(scene).to.have.property('name');
+      expect(scene.name).to.be.a('string');
+      expect(scene.name.startsWith('group_')).to.be.true;
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(scene).to.have.property('_id');
+      expect(scene._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(scene.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(scene).to.have.property('_rule');
+      expect(scene._rule).to.be.an('object');
+      expect(scene._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      scene = new Scene({
+        _id: 2501,
+        name: 'Rome',
+        background: 'red',
+        padding: 'ridiculous',
+        scales: [72, 91],
+        legends: [],
+        axes: [361],
+        marks: [1, 2, 3, 5, 8, 13, 21, 34]
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(scene).to.have.property('name');
+      expect(scene.name).to.be.a('string');
+      expect(scene.name).to.equal('Rome');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(scene).to.have.property('_id');
+      expect(scene._id).to.be.a('number');
+      expect(scene._id).to.equal(2501);
+    });
+
+    it('initializes instance with other keys and values from the provided props object', function() {
+      expect(scene).to.have.property('background');
+      expect(scene.background).to.equal('red');
+      expect(scene).to.have.property('padding');
+      expect(scene.padding).to.equal('ridiculous');
+    });
+
+    it('initializes instance with the child collections from the provided properties', function() {
+      expect(scene.scales).to.deep.equal([72, 91]);
+      expect(scene.legends).to.deep.equal([]);
+      expect(scene.axes).to.deep.equal([361]);
+      expect(scene.marks).to.deep.equal([1, 2, 3, 5, 8, 13, 21, 34]);
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(scene).to.have.property('_rule');
+      expect(scene._rule).to.be.an('object');
+      expect(scene._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('child method', function() {
+
+    beforeEach(function() {
+      scene = new Scene();
+    });
+
+    it('is a function', function() {
+      expect(scene).to.have.property('child');
+      expect(scene.child).to.be.a('function');
+    });
+
+    it('creates and returns child primitives within the scene', function() {
+      [
+        'axes',
+        'legends',
+        'marks.group',
+        'marks.rect',
+        'marks.symbol'
+      ].forEach(function(primitiveType) {
+        var child = scene.child(primitiveType);
+        expect(child).to.be.an('object');
+        expect(child.parent()).to.equal(scene);
+      });
+    });
+
+    it('creates a scale but does not assign itself as parent', function() {
+      var scale = scene.child('scales');
+      expect(scale.parent).to.be.null;
+    });
+
+    it('throws an error if provided an invalid type', function() {
+      expect(function() {
+        scene.child('unsupported primitive');
+      }).to.throw;
+    });
+
+    it('can insert a pre-existing primitive into a scene', function() {
+      var otherGroup = new Group();
+      expect(otherGroup.parent()).not.to.equal(scene);
+      scene.child('marks.scene', otherGroup);
+      expect(otherGroup.parent()).to.equal(scene);
+    });
+
+  });
+
+});

--- a/src/js/model/primitives/marks/Symbol.js
+++ b/src/js/model/primitives/marks/Symbol.js
@@ -1,6 +1,5 @@
 'use strict';
-var dl = require('datalib'),
-    inherits = require('inherits'),
+var inherits = require('inherits'),
     sg = require('../../../model/signals'),
     Mark = require('./Mark'),
     anchorTarget = require('../../../util/anchor-target'),
@@ -16,22 +15,38 @@ var DELTA = sg.DELTA,
  * @extends {Mark}
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'symbol')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Symbol() {
-  Mark.call(this, {
+function Symbol(props) {
+  Mark.call(this, props || Symbol.defaultProperties());
+}
+
+inherits(Symbol, Mark);
+
+/**
+ * Returns an object representing the default values for a symbol mark,
+ * containing a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Symbol.defaultProperties = function() {
+  return {
     type: 'symbol',
-    properties: {
+    // name: 'symbol' + '_' + counter.type('symbol'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
       update: {
         size: {value: 100},
         shape: {value: 'circle'}
       }
-    }
-  });
-
-  return this;
-}
-
-inherits(Symbol, Mark);
+    })
+  };
+};
 
 Symbol.prototype.initHandles = function() {
   var at = anchorTarget.bind(null, this, 'handles'),
@@ -53,6 +68,13 @@ Symbol.prototype.initHandles = function() {
   ]);
 };
 
+Symbol.SHAPES = [
+  'circle',
+  'square',
+  'cross',
+  'diamond',
+  'triangle-up',
+  'triangle-down'
+];
+
 module.exports = Symbol;
-Symbol.SHAPES = ['circle', 'square', 'cross',
-  'diamond', 'triangle-up', 'triangle-down'];

--- a/src/js/model/primitives/marks/Symbol.js
+++ b/src/js/model/primitives/marks/Symbol.js
@@ -18,14 +18,14 @@ var DELTA = sg.DELTA,
  * @constructor
  */
 function Symbol() {
-  Mark.call(this, 'symbol');
-
-  var props = this.properties,
-      update = props.update;
-
-  dl.extend(update, {
-    size: {value: 100},
-    shape: {value: 'circle'}
+  Mark.call(this, {
+    type: 'symbol',
+    properties: {
+      update: {
+        size: {value: 100},
+        shape: {value: 'circle'}
+      }
+    }
   });
 
   return this;

--- a/src/js/model/primitives/marks/Symbol.test.js
+++ b/src/js/model/primitives/marks/Symbol.test.js
@@ -73,14 +73,14 @@ describe('Symbol Mark Primitive', function() {
       expect(symbol.properties).to.be.an('object');
       expect(symbol.properties).to.deep.equal({
         update: {
-            x: {value: 25},
-            y: {value: 25},
-            fill: {value: '#4682b4'},
-            fillOpacity: {value: 1},
-            stroke: {value: '#000000'},
-            strokeWidth: {value: 0.25},
-            size: {value: 100},
-            shape: {value: 'circle'}
+          x: {value: 25},
+          y: {value: 25},
+          fill: {value: '#4682b4'},
+          fillOpacity: {value: 1},
+          stroke: {value: '#000000'},
+          strokeWidth: {value: 0.25},
+          size: {value: 100},
+          shape: {value: 'circle'}
         }
       });
     });

--- a/src/js/model/primitives/marks/Symbol.test.js
+++ b/src/js/model/primitives/marks/Symbol.test.js
@@ -1,0 +1,165 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+
+var expect = require('chai').expect;
+
+var Symbol = require('./Symbol');
+var Mark = require('./Mark');
+var VLSingle = require('../../rules/VLSingle');
+
+describe('Symbol Mark Primitive', function() {
+  var symbol;
+
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Symbol).to.have.property('defaultProperties');
+      expect(Symbol.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Symbol.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'symbol',
+        properties: {
+          update: {
+            x: {value: 25},
+            y: {value: 25},
+            fill: {value: '#4682b4'},
+            fillOpacity: {value: 1},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 0.25},
+            size: {value: 100},
+            shape: {value: 'circle'}
+          }
+        }
+      });
+    });
+
+  });
+
+  describe('constructor', function() {
+
+    beforeEach(function() {
+      symbol = new Symbol();
+    });
+
+    it('is a constructor function', function() {
+      expect(Symbol).to.be.a('function');
+    });
+
+    it('may be used to create symbol instances', function() {
+      expect(symbol).to.be.an.instanceOf(Symbol);
+    });
+
+    it('inherits from Mark', function() {
+      expect(symbol).to.be.an.instanceOf(Mark);
+    });
+
+    it('initializes instance with a .type property of "symbol"', function() {
+      expect(symbol).to.have.property('type');
+      expect(symbol.type).to.be.a('string');
+      expect(symbol.type).to.equal('symbol');
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(symbol).to.have.property('name');
+      expect(symbol.name).to.be.a('string');
+      expect(symbol.name.startsWith('symbol_')).to.be.true;
+    });
+
+    it('initializes instance with default vega properties', function() {
+      expect(symbol).to.have.property('properties');
+      expect(symbol.properties).to.be.an('object');
+      expect(symbol.properties).to.deep.equal({
+        update: {
+            x: {value: 25},
+            y: {value: 25},
+            fill: {value: '#4682b4'},
+            fillOpacity: {value: 1},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 0.25},
+            size: {value: 100},
+            shape: {value: 'circle'}
+        }
+      });
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(symbol).to.have.property('_id');
+      expect(symbol._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(symbol.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(symbol).to.have.property('_rule');
+      expect(symbol._rule).to.be.an('object');
+      expect(symbol._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('Constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      symbol = new Symbol({
+        type: 'symbol',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            fill: '#010101'
+          }
+        }
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(symbol).to.have.property('name');
+      expect(symbol.name).to.be.a('string');
+      expect(symbol.name).to.equal('Spartacus');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(symbol).to.have.property('_id');
+      expect(symbol._id).to.be.a('number');
+      expect(symbol._id).to.equal(2501);
+    });
+
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(symbol).to.have.property('properties');
+      expect(symbol.properties).to.deep.equal({
+        update: {
+          fill: '#010101'
+        }
+      });
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(symbol).to.have.property('_rule');
+      expect(symbol._rule).to.be.an('object');
+      expect(symbol._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('static property options lists', function() {
+
+    it('exposes a static property defining alignment options', function() {
+      expect(Symbol).to.have.property('SHAPES');
+      expect(Symbol.SHAPES).to.deep.equal([
+        'circle',
+        'square',
+        'cross',
+        'diamond',
+        'triangle-up',
+        'triangle-down'
+      ]);
+    });
+
+  });
+
+});

--- a/src/js/model/primitives/marks/Text.js
+++ b/src/js/model/primitives/marks/Text.js
@@ -19,23 +19,26 @@ var DELTA = sg.DELTA,
  * @constructor
  */
 function Text() {
-  Mark.call(this, 'text');
-
-  dl.extend(this.properties.update, {
-    strokeWidth: {value: 0},
-    x: {value: 80},
-    y: {value: 30},
-    dx: {value: 0, offset: 0},
-    dy: {value: 0, offset: 0},
-    // Text-specific properties
-    text: {value: 'Text'},
-    align: {value: 'center'},
-    baseline: {value: 'middle'},
-    font: {value: 'Helvetica'},
-    fontSize: {value: 14},
-    fontStyle: {value: 'normal'},
-    fontWeight: {value: 'normal'},
-    angle: {value: 0}
+  Mark.call(this, {
+    type: 'text',
+    properties: {
+      update: {
+        strokeWidth: {value: 0},
+        x: {value: 80},
+        y: {value: 30},
+        dx: {value: 0, offset: 0},
+        dy: {value: 0, offset: 0},
+        // Text-specific properties
+        text: {value: 'Text'},
+        align: {value: 'center'},
+        baseline: {value: 'middle'},
+        font: {value: 'Helvetica'},
+        fontSize: {value: 14},
+        fontStyle: {value: 'normal'},
+        fontWeight: {value: 'normal'},
+        angle: {value: 0}
+      }
+    }
   });
 
   return this;

--- a/src/js/model/primitives/marks/Text.js
+++ b/src/js/model/primitives/marks/Text.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var dl = require('datalib'),
-    inherits = require('inherits'),
+var inherits = require('inherits'),
     sg = require('../../../model/signals'),
     Mark = require('./Mark'),
     anchorTarget = require('../../../util/anchor-target'),
@@ -17,11 +16,31 @@ var DELTA = sg.DELTA,
  * @extends {Mark}
  *
  * @constructor
+ * @param {Object} [props] - An object defining this mark's properties
+ * @param {string} props.type - The type of mark (should be 'text')
+ * @param {Object} props.properties - A Vega mark properties object
+ * @param {string} [props.name] - The name of the mark
+ * @param {number} [props._id] - A unique mark ID
  */
-function Text() {
-  Mark.call(this, {
+function Text(props) {
+  Mark.call(this, props || Text.defaultProperties());
+}
+
+inherits(Text, Mark);
+
+/**
+ * Returns an object representing the default values for a rect text, containing
+ * a type string and a Vega mark properties object.
+ *
+ * @static
+ * @returns {Object} The default mark properties
+ */
+Text.defaultProperties = function() {
+  return {
     type: 'text',
-    properties: {
+    // name: 'text' + '_' + counter.type('text'); // Assign name in the reducer
+    // _id: assign ID in the reducer
+    properties: Mark.mergeProperties(Mark.defaultProperties(), {
       update: {
         strokeWidth: {value: 0},
         x: {value: 80},
@@ -38,13 +57,9 @@ function Text() {
         fontWeight: {value: 'normal'},
         angle: {value: 0}
       }
-    }
-  });
-
-  return this;
-}
-
-inherits(Text, Mark);
+    })
+  };
+};
 
 Text.prototype.initHandles = function() {
   var at = anchorTarget.bind(null, this, 'handles'),

--- a/src/js/model/primitives/marks/Text.test.js
+++ b/src/js/model/primitives/marks/Text.test.js
@@ -5,15 +5,53 @@ var expect = require('chai').expect;
 
 var Text = require('./Text');
 var Mark = require('./Mark');
+var VLSingle = require('../../rules/VLSingle');
 
-describe('Text Mark', function() {
+describe('Text Mark Primitive', function() {
   var text;
 
-  beforeEach(function() {
-    text = new Text();
+  describe('defaultProperties static method', function() {
+
+    it('is a function', function() {
+      expect(Text).to.have.property('defaultProperties');
+      expect(Text.defaultProperties).to.be.a('function');
+    });
+
+    it('returns the expected default properties object', function() {
+      var result = Text.defaultProperties();
+      expect(result).to.deep.equal({
+        type: 'text',
+        properties: {
+          update: {
+            fill: {value: '#4682b4'},
+            fillOpacity: {value: 1},
+            stroke: {value: '#000000'},
+            strokeWidth: {value: 0},
+            x: {value: 80},
+            y: {value: 30},
+            dx: {value: 0, offset: 0},
+            dy: {value: 0, offset: 0},
+            // Text-specific properties
+            text: {value: 'Text'},
+            align: {value: 'center'},
+            baseline: {value: 'middle'},
+            font: {value: 'Helvetica'},
+            fontSize: {value: 14},
+            fontStyle: {value: 'normal'},
+            fontWeight: {value: 'normal'},
+            angle: {value: 0}
+          }
+        }
+      });
+    });
+
   });
 
   describe('constructor', function() {
+
+    beforeEach(function() {
+      text = new Text();
+    });
 
     it('is a constructor function', function() {
       expect(Text).to.be.a('function');
@@ -25,6 +63,103 @@ describe('Text Mark', function() {
 
     it('inherits from Mark', function() {
       expect(text).to.be.an.instanceOf(Mark);
+    });
+
+    it('initializes instance with a .type property of "text"', function() {
+      expect(text).to.have.property('type');
+      expect(text.type).to.be.a('string');
+      expect(text.type).to.equal('text');
+    });
+
+    it('initializes instance with an appropriate .name property', function() {
+      expect(text).to.have.property('name');
+      expect(text.name).to.be.a('string');
+      expect(text.name.startsWith('text_')).to.be.true;
+    });
+
+    it('initializes instance with default vega properties', function() {
+      expect(text).to.have.property('properties');
+      expect(text.properties).to.be.an('object');
+      expect(text.properties).to.deep.equal({
+        update: {
+          fill: {value: '#4682b4'},
+          fillOpacity: {value: 1},
+          stroke: {value: '#000000'},
+          strokeWidth: {value: 0},
+          x: {value: 80},
+          y: {value: 30},
+          dx: {value: 0, offset: 0},
+          dy: {value: 0, offset: 0},
+          // Text-specific properties
+          text: {value: 'Text'},
+          align: {value: 'center'},
+          baseline: {value: 'middle'},
+          font: {value: 'Helvetica'},
+          fontSize: {value: 14},
+          fontStyle: {value: 'normal'},
+          fontWeight: {value: 'normal'},
+          angle: {value: 0}
+        }
+      });
+    });
+
+    it('initializes instance with a numeric _id', function() {
+      expect(text).to.have.property('_id');
+      expect(text._id).to.be.a('number');
+    });
+
+    it('does not initialize instance with a .from property', function() {
+      expect(text.from).to.be.undefined;
+    });
+
+    it('initializes instance with a ._rule object', function() {
+      expect(text).to.have.property('_rule');
+      expect(text._rule).to.be.an('object');
+      expect(text._rule).to.be.an.instanceOf(VLSingle);
+    });
+
+  });
+
+  describe('Constructor with non-default properties', function() {
+
+    beforeEach(function() {
+      text = new Text({
+        type: 'text',
+        _id: 2501,
+        name: 'Spartacus',
+        properties: {
+          update: {
+            fill: '#010101'
+          }
+        }
+      });
+    });
+
+    it('initializes instance with the name from the provided props object', function() {
+      expect(text).to.have.property('name');
+      expect(text.name).to.be.a('string');
+      expect(text.name).to.equal('Spartacus');
+    });
+
+    it('initializes instance with the _id from the provided props object', function() {
+      expect(text).to.have.property('_id');
+      expect(text._id).to.be.a('number');
+      expect(text._id).to.equal(2501);
+    });
+
+    it('initializes instance with the .properties from the provided props object', function() {
+      expect(text).to.have.property('properties');
+      expect(text.properties).to.deep.equal({
+        update: {
+          fill: '#010101'
+        }
+      });
+    });
+
+    it('still initializes instance with a ._rule object', function() {
+      expect(text).to.have.property('_rule');
+      expect(text._rule).to.be.an('object');
+      expect(text._rule).to.be.an.instanceOf(VLSingle);
     });
 
   });


### PR DESCRIPTION
**Description of the problem this pull request fixes**

Mark properties used to be set within the constructor in such a way that they could not be modified or overwritten until the object was fully instantiated and returned. That is inefficient for us because we want to be able to create primitives on demand from exported JSON or stored redux state. This PR alters the flow to allow each primitive to be instantiated by passing in a configuration object defining its state.

Marks to be updated to follow this pattern:
- [x] Area.js
- [x] Group.js
- [x] Line.js
- [x] Mark.js
- [x] Rect.js
- [ ] Scene.js
- [x] Symbol.js
- [x] Text.js

**This PR includes:**
- [x] Tests
- [ ] functional comments

**Steps to functionally test this:**
- Smoke & functional
- Does anything break that used to work?
