### PR TITLE
Fix signals flow

### DIFF
--- a/src/js/components/inspectors/Property.jsx
+++ b/src/js/components/inspectors/Property.jsx
@@ -11,7 +11,7 @@ var Property = React.createClass({
 
   unbind: function() {
     var props = this.props;
-    props.primitive.bind(props.name, undefined);
+    props.primitive.bindProp(props.name, undefined);
     props.reparse();
   },
 

--- a/src/js/components/mixins/SignalValue.jsx
+++ b/src/js/components/mixins/SignalValue.jsx
@@ -1,6 +1,8 @@
 'use strict';
 var dl = require('datalib'),
     sg = require('../../model/signals'),
+    store = require('../../store'),
+    setSignal = require('../../actions/setSignal'),
     model = require('../../model');
 
 module.exports = {
@@ -49,6 +51,11 @@ module.exports = {
   },
 
   signal: function(_, value) {
+    // Flow changes from Vega back up to the store
+    var signal = this.props.signal;
+    if (signal) {
+      store.dispatch(setSignal(signal, value));
+    }
     this.setState({value: value});
   },
 

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -107,7 +107,7 @@ var DataTable = React.createClass({
         // vega-lite (see the rules index file) -- looks up what channel we're
         // on, finds a vega-lite property, puts that in the rules object,
         // calls vega lite compile, then iterates through each part of the rule.
-        prim.bind(cell.key, fullField._id);
+        prim.bindProp(cell.key, selectedField._id);
       }
     } catch (e) {
       console.warn('Unable to bind primitive');

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -49,7 +49,12 @@ var DataTable = React.createClass({
         schema = this.props.dataset.schema();
 
     this.hideFull(evt);
-    this.setState({fullField: schema[name]});
+    this.setState({
+      // fullField is used for rendering
+      fullField: schema[name],
+      // selectedField is used to pass data around while dragging
+      selectedField: schema[name]
+    });
     this._fullField.style('display', 'block')
       .style('top', target.offsetTop);
   },
@@ -96,7 +101,7 @@ var DataTable = React.createClass({
   handleDragEnd: function(evt) {
     var sel = sg.get(sg.SELECTED),
         cell = sg.get(sg.CELL),
-        fullField = this.state.fullField,
+        selectedField = this.state.selectedField,
         dropped = sel._id && cell._id,
         prim;
 

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -180,7 +180,7 @@ var DataTable = React.createClass({
                     onMouseOver={this.showFullField}>{k}</td>
                   {values.map(function(v, i) {
                     return (
-                      <td key={v._id} className={i % 2 ? 'even' : 'odd'}
+                      <td key={k + i} className={i % 2 ? 'even' : 'odd'}
                         onMouseOver={this.showFullValue}>{v[k]}</td>
                     );
                   }, this)}

--- a/src/js/model/rules/index.js
+++ b/src/js/model/rules/index.js
@@ -10,7 +10,7 @@ var dl = require('datalib'),
 
 function rules(prototype) {
 
-  prototype.bind = function(property, id, manual) {
+  prototype.bindProp = function(property, id, manual) {
     var rule = this._rule,
         from = this._from && lookup(this._from),
         obj = lookup(id),

--- a/src/js/model/rules/scales.js
+++ b/src/js/model/rules/scales.js
@@ -99,7 +99,7 @@ module.exports = function(parsed) {
     if (!def) {
       continue;
     }
-    if (!curr || !equals(def, curr)) {
+    if (!curr || !equals.call(this, def, curr)) {
       scale.call(this, def);
     }
   }

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -92,9 +92,13 @@ api.get = function(name) {
 api.set = function(name, val) {
   var model = require('../'),
       view = model.view;
+  // Always flow signals up to the store,
   if (!isDefault(name)) {
     store.dispatch(setSignal(name, val));
-  } else if (view && typeof view.signal === 'function') {
+  }
+
+  // and if we have a Vega view, flow signals down to Vega as well.
+  if (view && typeof view.signal === 'function') {
     // The default signals do not get saved in the store, but they need to be passed
     // through to vega in order for channels, etc to work. Check for view because
     // it may not have been initialized yet.

--- a/src/js/store/listeners.js
+++ b/src/js/store/listeners.js
@@ -91,31 +91,6 @@ function updateSelectedMarkInVega(selectedMark, vegaView) {
 }
 
 /**
- * Setting the same value on a signal twice should have no effect, so  we
- * naively set all signals on each store update to ensure store and Vega
- * stay in sync. Altering this to be smarter is one area to investigate should
- * any performance issues crop up later on, but signal writes are pretty fast.
- *
- * @param {Object} state - An Immutable state object
- * @param {Object} vegaView - A vega view instance to update with the selected mark
- * @returns {void}
- */
-function updateAllSignals(state, vegaView) {
-  getIn(state, 'signals').forEach(function(value, name) {
-    // Skip any signal from the defaults
-    if (sg.isDefault(name)) {
-      return;
-    }
-
-    // Persist any signals from the store to the view: wrap this in a try/catch
-    // to handle situations where the update fires while we are registering
-    // signals for new marks before a reparse has actually injected those marks
-    // into the vega view itself.
-    vegaView.signal(name, value.init);
-  });
-}
-
-/**
  * Return a master syncStoreToVega method created using the granular update
  * methods and an injected model and store. `recreateVegaIfNecessary`,
  * `updateSelectedMarkInVega`, and `updateAllSignals` are all consumed by local
@@ -157,9 +132,6 @@ function createStoreListener(store, model) {
     if (storeSelectedId) {
       updateSelectedMarkInVega(model.lookup(storeSelectedId), model.view);
     }
-
-    // Synchronize the Vega view with the signals within redux
-    updateAllSignals(state, model.view);
   };
 }
 
@@ -171,6 +143,5 @@ module.exports = {
   // normally wouldn't expose or test "internal" implementation details like
   // this, but doing so can give us added peace of mind with important code.
   _recreateVegaIfNecessary: recreateVegaIfNecessary,
-  _updateSelectedMarkInVega: updateSelectedMarkInVega,
-  _updateAllSignals: updateAllSignals
+  _updateSelectedMarkInVega: updateSelectedMarkInVega
 };


### PR DESCRIPTION
**Description of the problem this pull request fixes**

As described in #318, signal changes originating from vega (e.g. drag and drop actions) were not making it back up to the redux store, meaning that when the user selects any other object after dragging a handle, the mark they modified "snaps" back to where it began.

Additionally, channel interactions only sporadically persisted; sometimes dropping a value onto a channel would fail with a warning that an error had occurred.

Changes proposed in this pull request:
- sg.set _always_ flows changes both to the store _and_ to vega, if vega is available
- SignalValue mixin dispatches detected changes to the store to keep Redux in sync with Vega
- `.bind` function from the rules mixin has been renamed to `.rebind` to avoid confusion with `Function.prototype.bind`
- DataTable component has been updated so that the drag-and-drop action uses different state variables for data and for markup storage, fixing an issue where markup-targeted actions would null out the data pointer during a drag operation
- Rules code has been fixed to properly set the context of a function using `.call`
- DataTable code has been fixed to use array index for React `key` instead of `v._id`, because after a drop operation (droperation?) `v._id` becomes undefined. **This may point at a larger issue in how data is passed within the app** but fixing it was out of scope for this effort due to time constraint.

**Steps to functionally test this:**
- #318 issue:
  - Add a mark, e.g. a symbol
  - Drag the symbol around the stage
  - Deselect the symbol by clicking the stage or adding another mark
  - Symbol should remain where you left it
- Channel issues
  - Drag and drop various data sources onto the channels of marks
  - Data should be bound as expected
