### PR TITLE
Do not attempt to unset non-existent signals

### DIFF
--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -218,7 +218,7 @@ Mark.prototype.remove = function() {
     var signalName = update[key].signal;
     // Currently width and height are set on Groups to use the full width of the scene
     // they use the same signal name
-    if (signalName !== ns('vis_width') && signalName !== ns('vis_height')) {
+    if (signalName && signalName !== ns('vis_width') && signalName !== ns('vis_height')) {
       sg.delete(signalName);
     }
   }


### PR DESCRIPTION
**Description of the problem this pull request fixes**
## Changes proposed in this pull request:
## 

*\* If submitting code for review: **

**This PR includes:**
- [ ] Tests
- [ ] functional comments
- [ ] high level description of any new components

**Steps to functionally test this:**
## 
## 
## 

When a mark is initialized, its properties are initialized to signal
references; however, once that mark is bound to a data field, that
signal reference is replaced with a reference to the field and to
the scale it should use to interpret that field.

``` js
// Before binding data:
{ signal: 'lyra_rect_1_x' }

// After binding data:
{ field: 15, scale : 31 }
```

This code didn't account for the possibility that a property would
not have a signal value; the patch in this PR simply skips the
unset-signal step

Things this does not account for:
- Cleaning up fields and scales that were created for a mark;
  this may be out of scope for mark deletion, because those scales
  may be used elsewhere or _could_ be used elsewhere. Input from
  @arvind would be useful.
- Cleaning up the still-present-but-no-longer-in-use signals: we
  do not do anything to remove those signals from our signal store
  when we delete a mark. Changes I will make to the way signal
  deletion happens in conjunction with reducers should account for
  this problem.
