### PR TITLE
add footer, modal, and move some containers around

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div class="app">
-      <div id="sidebars" class="sidebar-container"></div>
+      <div id="sidebars"></div>
       <div class="vis-container">
         <div id="vis"></div>
       </div>

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.6",
     "react-dom": "^0.14.3",
+    "react-modal": "^1.0.0",
     "react-redux": "^4.4.1",
     "react-tooltip": "^1.1.4",
     "redux": "^3.3.1",

--- a/src/js/components/Footer.jsx
+++ b/src/js/components/Footer.jsx
@@ -1,0 +1,44 @@
+'use strict';
+var React = require('react'),
+    connect = require('react-redux').connect,
+    Modal = require('react-modal');
+
+
+var Footer = connect()(React.createClass({
+  getInitialState: function() {
+    return { modalIsOpen: false };
+  },
+
+  openModal: function() {
+    this.setState({modalIsOpen: true});
+  },
+
+  closeModal: function() {
+    this.setState({modalIsOpen: false});
+  },
+  classNames: 'site-footer',
+  render: function() {
+    return (
+      <footer className={this.classNames}>
+        <ul>
+          <li onClick={this.openModal}>About</li>
+          <li>Github</li>
+          <li>Walkthroughs</li>
+          <li>Settings</li>
+        </ul>
+        <Modal
+          isOpen={this.state.modalIsOpen}
+          onRequestClose={this.closeModal}>
+          <div className ="wrapper">
+            <span className="closeModal" onClick={this.closeModal}>close</span>
+            <h2>About the team... </h2>
+
+            <div>I am a modal</div>
+          </div>
+        </Modal>
+      </footer>
+    );
+  }
+}));
+
+module.exports = Footer;

--- a/src/js/components/Sidebars.jsx
+++ b/src/js/components/Sidebars.jsx
@@ -6,6 +6,7 @@ var React = require('react'),
     PipelinesSidebar = require('./PipelinesSidebar'),
     Toolbar = require('./Toolbar'),
     Hints = require('./Hints'),
+    Footer = require('./Footer'),
     model = require('../model');
 
 // Splitting each sidebar into its column
@@ -14,13 +15,16 @@ var Sidebars = React.createClass({
   render: function() {
     var pipelines = model.pipeline();
     return (
-      <div className={this.classNames}>
-        <VisualSidebar />
-        <InspectorSidebar ref="inspector"
-          pipelines={pipelines} />
-        <PipelinesSidebar />
+      <div>
+        <div className="sidebar-container">
+          <VisualSidebar />
+          <InspectorSidebar ref="inspector"
+            pipelines={pipelines} />
+          <PipelinesSidebar />
+        </div>
         <Toolbar/>
         <Hints/>
+        <Footer/>
         <ReactTooltip effect="solid"/>
       </div>
     );

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -10,6 +10,8 @@
 
 
 // components
+@import 'footer';
+@import 'modal';
 @import 'toolbar';
 @import 'hints';
 @import 'pipelines';

--- a/src/scss/footer.scss
+++ b/src/scss/footer.scss
@@ -1,0 +1,21 @@
+.site-footer {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 0 10px;
+  background-color: #fff;
+  ul {
+    margin: 0;
+    padding: 0;
+    li {
+      cursor: pointer;
+      padding: 10px;
+      display: inline-block;
+      &:hover {
+        background-color: #eee;
+      }
+    }
+  }
+  z-index: 9999;
+}

--- a/src/scss/hints.scss
+++ b/src/scss/hints.scss
@@ -2,7 +2,7 @@
   padding: 20px;
   background: #fff;
   position: absolute;
-  bottom: 0;
+  bottom: 40px;
   z-index: 999;
   border: 1px solid;
   left: 0;

--- a/src/scss/layers.scss
+++ b/src/scss/layers.scss
@@ -1,6 +1,6 @@
 #layer-list {
-  min-height: 60%;
-
+  height: 60%;
+  overflow-y: scroll;
   ul.group {
     white-space: nowrap;
     border-bottom: 1px solid $lgrey-bg;

--- a/src/scss/modal.scss
+++ b/src/scss/modal.scss
@@ -1,0 +1,17 @@
+.ReactModal__Overlay{
+  top: '50%';
+  left: '50%';
+  right: 'auto';
+  bottom: 'auto';
+  transform: 'translate(-50%, -50%)';
+  z-index: 9999;
+  .closeModal {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    cursor: pointer;
+  }
+  .wrapper {
+    padding:20px;
+  }
+}


### PR DESCRIPTION
#337 has a todo to add a modal.  I have a modal and a place for about stuff in my walkthrough branch.  I pulled that out into this branch so we aren't doubling work.

Changes proposed in this pull request:
- adds react modal
- adds footer
- moves a little bit of the markup around
- fixes an issue with the group sidebar not scrolling. 

**Steps to functionally test this:**
- click on About in the footer. A placeholder modal should appear. 

The look of the footer is very basic and unstyled. 

![modal](https://cloud.githubusercontent.com/assets/607541/14433757/734fe5ec-ffc4-11e5-8c7e-e59acfae8b2e.gif)
