### PR TITLE
close tooltip on delete

### DIFF
--- a/src/js/components/visualization/GroupSubMenu.jsx
+++ b/src/js/components/visualization/GroupSubMenu.jsx
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react'),
     connect = require('react-redux').connect,
+    ReactTooltip = require('react-tooltip'),
     ContentEditable = require('../ContentEditable'),
     lookup = require('../../model').lookup,
     hierarchy = require('../../util/hierarchy'),
@@ -72,11 +73,15 @@ var Group = connect(
     return iconMarkup;
   },
   deleteUpdate: function(id) {
+    ReactTooltip.hide();
     this.deleteMark(id);
     // set selected to null
     this.props.select(null);
     // redraw sidebar
     this.updateSidebar();
+  },
+  componentWillUnmount: function(){
+    ReactTooltip.hide();
   },
   render: function() {
     var props = this.props,


### PR DESCRIPTION
When a mark was deleted from the visualization sidebar, the tool tip wouldn't disapear. 

Changes proposed in this pull request:
- remove the tooltip on delete
- also remove the tooltip on unmount of the component (to be double safe) 

**Steps to functionally test this:**
1. make a group
2. delete it
3. tooltip should disappear

---
1. make a group
2. put a mark in the group
3. delete the mark in the group
4. tooltip should disappear
