### PR TITLE
Resolve pulse issue: Flow signal values to Lyra only through Vega

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "karma-sourcemap-loader": "^0.3.6",
     "karma-spec-reporter": "0.0.23",
     "karma-webpack": "^1.7.0",
-    "lodash.debounce": "^4.0.3",
-    "lodash.throttle": "^4.0.1",
     "minami": "^1.1.1",
     "mocha": "^2.4.5",
     "node-sass": "^3.4.2",

--- a/src/js/components/inspectors/Property.jsx
+++ b/src/js/components/inspectors/Property.jsx
@@ -5,25 +5,19 @@ var React = require('react'),
     ContentEditable = require('../ContentEditable'),
     model = require('../../model'),
     lookup = model.lookup,
-    resetProperty = require('../../actions/ruleActions').resetProperty,
-    vegaInvalidate = require('../../actions/vegaInvalidate'),
-    addVegaReparseRequest = require('../mixins/addVegaReparseRequest');
+    resetProperty = require('../../actions/ruleActions').resetProperty;
 
 function mapDispatchToProps(dispatch) {
   return {
     resetProperty: function(id, property) {
       dispatch(resetProperty(id, property));
-    },
-    requestReparse: function() {
-      dispatch(vegaInvalidate(true));
     }
   };
 }
 
 var Property = React.createClass({
   propTypes: {
-    resetProperty: React.PropTypes.func,
-    requestReparse: React.PropTypes.func
+    resetProperty: React.PropTypes.func
   },
 
   mixins: [SignalValue],
@@ -31,8 +25,6 @@ var Property = React.createClass({
   unbind: function() {
     var props = this.props;
     props.resetProperty(props.primitive._id, props.name);
-    // props.primitive.bindProp(props.name, undefined);
-    props.requestReparse();
   },
 
   render: function() {

--- a/src/js/components/mixins/SignalValue.jsx
+++ b/src/js/components/mixins/SignalValue.jsx
@@ -74,7 +74,9 @@ module.exports = {
     }
 
     if (signal) {
-      sg.set(signal, value);
+      // Set the signal on the view but do not dispatch: the `.signal` listener
+      // above will dispatch the action to synchronize Redux with Vega.
+      sg.set(signal, value, false);
       model.update();
     } else {
       this._set(props.obj, value);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,8 +3,6 @@
 
 require('../scss/app.scss');
 
-var throttle = require('lodash.throttle');
-
 // Additional requires to polyfill + browserify package.
 require('array.prototype.find');
 require('string.prototype.startswith');
@@ -20,11 +18,7 @@ var model = require('./model');
 var listeners = require('./store/listeners');
 
 // Bind the listener that will flow changes from the redux store into Vega.
-// Throttle the listener to avoid the rendering overhead of re-computing
-// certain properties from the store dispatch cycle more frequently than
-// 60fps (16 is derived from 1000ms / 60fps). This listener calls model.update
-// when it completes if the view is viable.
-store.subscribe(throttle(listeners.createStoreListener(store, model), 16));
+store.subscribe(listeners.createStoreListener(store, model));
 
 // Initializes the Lyra model with a new Scene primitive.
 var createScene = require('./actions/createScene');

--- a/src/js/model/signals/index.js
+++ b/src/js/model/signals/index.js
@@ -87,13 +87,14 @@ api.get = function(name) {
  *
  * @param {string} name - The name of the signal to set
  * @param {*} val - The value to set, often an object or a number
+ * @param {boolean} [dispatch=true] - Whether to dispatch the signal to the store
  * @returns {Object} The Signals API object
  */
-api.set = function(name, val) {
+api.set = function(name, val, dispatch) {
   var model = require('../'),
       view = model.view;
   // Always flow signals up to the store,
-  if (!isDefault(name)) {
+  if (!isDefault(name) && dispatch !== false) {
     store.dispatch(signalSet(name, val));
   }
 

--- a/src/js/store/listeners.js
+++ b/src/js/store/listeners.js
@@ -105,6 +105,7 @@ function updateSelectedMarkInVega(selectedMark, vegaView) {
   // If an item was found, set the Lyra mode signal so that the handles appear.
   if (item !== null) {
     vegaView.signal(sg.SELECTED, item);
+    vegaView.update();
   }
 }
 
@@ -151,8 +152,6 @@ function createStoreListener(store, model) {
     if (storeSelectedId) {
       updateSelectedMarkInVega(model.lookup(storeSelectedId), model.view);
     }
-
-    model.update();
   };
 }
 


### PR DESCRIPTION
Up to now I had been pursuing a strategy by which all changes to signal values flowed into the Lyra store and the Vega view simultaneously. Given that the store listener called model.update but was throttled, and that setting values on the store from within the SignalValue mixin both dispatched singals to store AND (once model.update was fired) triggered callbacks that themselves dispatched that same signal to the store, the state of signals inside the store could get ambiguous and therefore the model itself could be put into an invalid state by rapidly triggering many signal changes one after another (e.g. scrubbing the color of a mark in a color picker).

This adds a "dispatch" parameter to the `sg.set` method, which can be provided to opt-out a call to `sg.set` from passing the value to the store as well. Having this explicit opt-out claries the flow of information within the SignalValue mixin by which we keep both Vega _and_ the Redux store up-to-date with signal values:

**Case 1: User interacts w/ mark through handles**
1. User drags a handle
2. Vega updates the signal value internally: _Vega is now up to date_
3. Vega fires an onChange handler for that signal
4. Lyra hears that onChange event and dispatches the new signal value to the Redux store: _Redux is now up to date_

**Case 2: User interacts w/ mark through inspector**
1. User sets a value in the inspector
2. Lyra sets the singal value within Vega, but _not_ Redux
3. Lyra calls `model.update()`, triggering a Vega update that makes the new value take effect: _Vega is now up to date_
4. Vega fires an onChange handler for that signal
5. Lyra hears that onChange event and dispatches the new signal value to the Redux store: _Redux is now up to date_
