### PR TITLE
Store Listener cleanup

### DIFF
--- a/src/js/components/InspectorSidebar.jsx
+++ b/src/js/components/InspectorSidebar.jsx
@@ -18,9 +18,7 @@ function mapStateToProps(reduxState, ownProps) {
   };
 }
 
-var Inspector = connect(
-  mapStateToProps
-)(React.createClass({
+var Inspector = React.createClass({
   classNames: 'sidebar col5 push4 md-blue-bg',
   render: function() {
     var props = this.props,
@@ -60,11 +58,12 @@ var Inspector = connect(
       </div>
     );
   }
-}));
+});
 
-module.exports = Inspector;
 Inspector.Line = require('./inspectors/Line');
 Inspector.Rect = require('./inspectors/Rect');
 Inspector.Symbol = require('./inspectors/Symbol');
 Inspector.Text = require('./inspectors/Text');
 Inspector.Area = require('./inspectors/Area');
+
+module.exports = connect(mapStateToProps)(Inspector);

--- a/src/js/components/Sidebars.jsx
+++ b/src/js/components/Sidebars.jsx
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react'),
     connect = require('react-redux').connect,
+    getIn = require('../util/immutable-utils').getIn,
     ReactTooltip = require('react-tooltip'),
     InspectorSidebar = require('./InspectorSidebar'),
     VisualSidebar = require('./VisualSidebar'),
@@ -9,17 +10,21 @@ var React = require('react'),
     Hints = require('./Hints'),
     model = require('../model');
 
-// Use mapDispatchToProps to force sidebar to update as marks are added or
-// removed; this prop isn't actually used at this level yet.
+// Use mapDispatchToProps to force sidebar to update when the user makes any
+// change which would cause a re-render: this is clumsy but avoids forceUpdate
 function mapStateToProps(reduxState) {
-  var markIds = Object.keys(reduxState.get('primitives').toJS());
   return {
-    marks: markIds
+    // Vega "validity" is a good proxy for "has something been added or removed
+    // that we need to re-render globally to account for"
+    arbitraryPropToTriggerUpdate: getIn(reduxState, 'vega.invalid')
   };
 }
 
 // Splitting each sidebar into its column
 var Sidebars = React.createClass({
+  propTypes: {
+    arbitraryPropToTriggerUpdate: React.PropTypes.bool
+  },
   classNames: 'row',
   render: function() {
     var pipelines = model.pipeline();

--- a/src/js/components/Toolbar.jsx
+++ b/src/js/components/Toolbar.jsx
@@ -1,18 +1,10 @@
 'use strict';
 var React = require('react'),
-    connect = require('react-redux').connect,
     AddMarksTool = require('./tools/AddMarksTool'),
     UndoRedoClearTool = require('./tools/UndoRedoClearTool');
-// Splitting each sidebar into its column
 
-function mapStateToProps(reduxState, ownProps) {
-  return {
-    selected: reduxState.get('selectedMark')
-  };
-}
-var Toolbar = connect(
-  mapStateToProps
-)(React.createClass({
+// Splitting each sidebar into its column
+var Toolbar = React.createClass({
   classNames: 'toolbar',
   render: function() {
     return (
@@ -33,6 +25,6 @@ var Toolbar = connect(
       </div>
     );
   }
-}));
+});
 
 module.exports = Toolbar;

--- a/src/js/components/tools/AddMarksTool.jsx
+++ b/src/js/components/tools/AddMarksTool.jsx
@@ -1,26 +1,17 @@
 'use strict';
 var React = require('react'),
     connect = require('react-redux').connect,
+    store = require('../../store'),
     getIn = require('../../util/immutable-utils').getIn,
     getClosestGroupId = require('../../util/store-utils').getClosestGroupId,
     marks = require('../../model/primitives/marks'),
     selectMark = require('../../actions/selectMark'),
     addMark = require('../../actions/primitiveActions').addMark;
 
-function mapStateToProps(reduxState, ownProps) {
-  var selectedMarkId = getIn(reduxState, 'inspector.selected'),
-      sceneId = getIn(reduxState, 'scene.id'),
-      closestContainerId;
-
-  // Closest container is determined by walking up from the selected mark,
-  // otherwise it defaults to the scene itself
-  closestContainerId = selectedMarkId ?
-    getClosestGroupId(reduxState, selectedMarkId) :
-    sceneId;
-
+function mapStateToProps(reduxState) {
   return {
-    selected: selectedMarkId,
-    container: closestContainerId
+    selectedId: getIn(reduxState, 'inspector.selected'),
+    sceneId: getIn(reduxState, 'scene.id')
   };
 }
 
@@ -43,19 +34,24 @@ var marksArray = ['rect', 'symbol', 'area', 'text', 'line'];
 
 var AddMarksTool = React.createClass({
   propTypes: {
+    selectedId: React.PropTypes.number,
+    sceneId: React.PropTypes.number,
     addMark: React.PropTypes.func,
-    container: React.PropTypes.number,
-    selectMark: React.PropTypes.func,
-    selected: React.PropTypes.number
+    selectMark: React.PropTypes.func
   },
   classNames: 'new-marks',
   render: function() {
-    var parentId = this.props.container;
+    // Closest container is determined by walking up from the selected mark,
+    // otherwise it defaults to the scene itself
+    var closestContainerId = this.props.selectedId ?
+      getClosestGroupId(store.getState(), this.props.selectedId) :
+      this.props.sceneId;
+
     return (
       <ul className={this.classNames}>
         {marksArray.map(function(markType, i) {
           return (
-            <li key={markType} onClick={this.props.addMark.bind(null, markType, parentId)}>
+            <li key={markType} onClick={this.props.addMark.bind(null, markType, closestContainerId)}>
               {markType}
             </li>
           );

--- a/src/js/components/visualization/ScaleList.jsx
+++ b/src/js/components/visualization/ScaleList.jsx
@@ -5,20 +5,19 @@ var React = require('react'),
 
 function mapStateToProps(reduxState, ownProps) {
   return {
-    selected: reduxState.get('selectedMark')
+    selectedId: reduxState.get('selectedMark')
   };
 }
 
-var ScaleList = connect(
-  mapStateToProps
-)(React.createClass({
+var ScaleList = React.createClass({
   propTypes: {
     select: React.PropTypes.func,
-    selected: React.PropTypes.number
+    selectedId: React.PropTypes.number,
+    scales: React.PropTypes.array
   },
   render: function() {
     var props = this.props,
-        selected = props.selected;
+        selectedId = props.selectedId;
     return (
       <div id="scale-list" className="expandingMenu">
         <h4 className="hed-tertiary">
@@ -32,7 +31,7 @@ var ScaleList = connect(
           {props.scales.map(function(scale) {
             var id = scale._id;
             return (
-              <li key={id} className={selected === id ? 'selected' : ''}>
+              <li key={id} className={selectedId === id ? 'selected' : ''}>
                 <div className="scale name">
                   <ContentEditable obj={scale} prop="name"
                     value={scale.name}/>
@@ -44,6 +43,6 @@ var ScaleList = connect(
       </div>
     );
   }
-}));
+});
 
-module.exports = ScaleList;
+module.exports = connect(mapStateToProps)(ScaleList);

--- a/src/js/reducers/inspector.js
+++ b/src/js/reducers/inspector.js
@@ -32,7 +32,16 @@ function inspectorReducer(state, action) {
 
   // Auto-select new marks
   if (action.type === actions.PRIMITIVE_ADD_MARK) {
-    return state.set('selected', action.id);
+    // Select the mark, then attempt to auto-expand it (and its specified parent)
+    return setIn(
+      setIn(
+        state.set('selected', action.id),
+        'expandedLayers.' + action.id,
+        true
+      ),
+      'expandedLayers.' + action.props._parent,
+      true
+    );
   }
 
   if (action.type === actions.SELECT_MARK) {


### PR DESCRIPTION
**Description of the problem this pull request fixes**

This PR does two unrelated things (sorry): First, it makes it so that when you add a mark, it auto-expands that mark and/or the mark's parent in the inspector sidebar:

Before:

![mark-expand-before](https://cloud.githubusercontent.com/assets/442115/14498632/104a5ae4-0169-11e6-98ad-23e20bd3501a.gif)

After:

![mark-expand-after](https://cloud.githubusercontent.com/assets/442115/14498638/1611d1fa-0169-11e6-923d-9d5e61931d70.gif)

This also makes a small but conceptually valuable change to the work done in `mapStateToProps`: wherever possible `mapStateToProps` should not be used for any purpose beyond **reading values from the store**, and **should only return values comparable by basic equality**.

To elaborate, `mapStateToProps` fires on every digest cycle; the component's Render will only fire when the values returned from `mapStateToProps` change, where "change" is determined by equality. For this reason, we should preference returning basic types from `mapStateToProps` (string, number, boolean) and Immutable constructs, rather than objects or arrays, because all of the former (including Immutable constructs) can be compared by equality: any sort of `.toJS`, `.toObject`, etc, which generates a value that cannot be compared by equality, should be handled in `.render` and not in `mapStateToProps`, to avoid equivalent objects like `{1: true}` and `{1: true}` being viewed as "different" values and therefore triggering unnecessary (and therefore wasteful) re-renders.

**Changes proposed in this pull request:**
- Auto-expand newly-added marks and their parents
- Return basic types and Immutable constructs from `mapStateToProps`, not objects or arrays
- Only include `ownProps` in map\* methods when necessary

**Steps to functionally test this:**
- The usual
