### PR TITLE
Remove deprecated .parent and .child prototype methods

### DIFF
--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -4,7 +4,6 @@
 var dl = require('datalib'),
     sg = require('../signals'),
     model = require('../'),
-    lookup = model.lookup,
     counter = require('../../util/counter');
 
 /**
@@ -64,21 +63,5 @@ Primitive.prototype.export = function(clean) {
  * @returns {Object} A Vega specification.
  */
 Primitive.prototype.manipulators = Primitive.prototype.export;
-
-/**
- * Gets or sets the parent of the Primitive. A Primitive's parent represents a
- * "contains" relationship. Thus, a Primitive may have only one parent but a
- * single parent may have many children.
- * @param  {number} [pid] - The ID of the parent to set.
- * @returns {Object} The parent Primitive, if called as a getter, otherwise the
- * current Primitive.
- */
-Primitive.prototype.parent = function(pid) {
-  if (!pid) {
-    return lookup(this._parent);
-  }
-  this._parent = Number(pid);
-  return this;
-};
 
 module.exports = Primitive;

--- a/src/js/model/primitives/Scale.js
+++ b/src/js/model/primitives/Scale.js
@@ -4,6 +4,7 @@ var dl = require('datalib'),
     Primitive = require('./Primitive'),
     model = require('../'),
     lookup = model.lookup,
+    getParent = require('../../util/hierarchy').getParent,
     names = {};
 
 // To prevent name collisions.
@@ -71,13 +72,16 @@ function dataRef(ref) {
   // One ref
   if (ref.length === 1 && (ref = ref[0])) {
     field = lookup(ref);
-    return {data: field.parent().name, field: field._name};
+    return {
+      data: getParent(field).name,
+      field: field._name
+    };
   }
 
   // More than one ref
   for (i = 0, len = ref.length; i < len; ++i) {
     field = lookup(ref[i]);
-    data = field.parent();
+    data = getParent(field);
     sets[data._id] = sets[data._id] || (sets[data._id] = []);
     sets[data._id].push(field);
   }

--- a/src/js/model/primitives/data/Dataset.js
+++ b/src/js/model/primitives/data/Dataset.js
@@ -12,17 +12,22 @@ var dl = require('datalib'),
  * @extends {Primitive}
  *
  * @param {string} name - The name of the dataset.
+ * @param {number} [_parent] - The ID of the dataset's parent.
  * @see  Vega's {@link https://github.com/vega/vega/wiki/Data|Data source}
  * documentation for more information on this class' "public" properties.
  *
  * @constructor
  */
-function Dataset(name) {
+function Dataset(name, _parent) {
   this.name = name;
 
   this.source = undefined;
   this.url = undefined;
   this.format = undefined;
+
+  if (_parent) {
+    this._parent = _parent;
+  }
 
   return Primitive.call(this);
 }
@@ -86,7 +91,7 @@ Dataset.prototype.schema = function() {
       types = dl.type.inferAll(this.output());
 
   var schema = dl.keys(types).reduce(function(s, k) {
-    s[k] = new Field(k, types[k]).parent(that._id);
+    s[k] = new Field(k, types[k], that._id);
     return s;
   }, {});
 

--- a/src/js/model/primitives/data/Field.js
+++ b/src/js/model/primitives/data/Field.js
@@ -3,6 +3,7 @@ var dl = require('datalib'),
     vl = require('vega-lite'),
     inherits = require('inherits'),
     Primitive = require('../Primitive'),
+    getParent = require('../../../util/hierarchy').getParent,
     TYPES = vl.data.types;
 
 /**
@@ -15,6 +16,7 @@ var dl = require('datalib'),
  * @param {string} name - The name of the field.
  * @param {string} ptype - The JavaScript primitive type of the field
  * (boolean, string, etc.).
+ * @param {number} [_parent] - The ID of the field's parent datasource
  *
  * @property {string} _name - The name of the field.
  * @property {string} _ptype - The JavaScript primitive type of the field
@@ -26,7 +28,7 @@ var dl = require('datalib'),
  *
  * @constructor
  */
-function Field(name, ptype) {
+function Field(name, ptype, _parent) {
   this._name = name;
   this._ptype = ptype;         // primitive type (boolean/string/etc.)
   this._type = TYPES[ptype];  // nominal, ordinal, etc.
@@ -35,6 +37,10 @@ function Field(name, ptype) {
   this._bin = null;
 
   this.$ = dl.$(name);
+
+  if (_parent) {
+    this._parent = _parent;
+  }
 
   return Primitive.call(this);
 }
@@ -56,7 +62,7 @@ Field.prototype.profile = function(p) {
     return this._profile;
   }
 
-  return (this.parent().summary(), this._profile);
+  return (getParent(this).summary(), this._profile);
 };
 
 module.exports = Field;

--- a/src/js/model/primitives/data/Pipeline.js
+++ b/src/js/model/primitives/data/Pipeline.js
@@ -21,7 +21,7 @@ var inherits = require('inherits'),
 function Pipeline(name) {
   Primitive.call(this);
   this.name = name;
-  this._source = new Dataset(name).parent(this._id);
+  this._source = new Dataset(name, this._id);
   this._aggregates = [];
   return this;
 }

--- a/src/js/model/primitives/marks/Group.test.js
+++ b/src/js/model/primitives/marks/Group.test.js
@@ -7,10 +7,9 @@ var Group = require('./Group');
 var Mark = require('./Mark');
 var ns = require('../../../util/ns');
 var VLSingle = require('../../rules/VLSingle');
-var model = require('../../');
 
 describe('Group Mark', function() {
-  var group, subgroup;
+  var group;
 
   describe('defaultProperties static method', function() {
 
@@ -195,121 +194,4 @@ describe('Group Mark', function() {
 
   });
 
-  describe('child method', function() {
-
-    beforeEach(function() {
-      group = new Group();
-      // Shim to handle the ID binding that no longer occurs in Mark instances
-      group._id = 1;
-      model.primitive(group._id, group);
-    });
-
-    it('is a function', function() {
-      expect(group).to.have.property('child');
-      expect(group.child).to.be.a('function');
-    });
-
-    it('creates and returns child primitives within the group', function() {
-      [
-        'axes',
-        'legends',
-        'marks.group',
-        'marks.rect',
-        'marks.symbol'
-      ].forEach(function(primitiveType) {
-        var child = group.child(primitiveType);
-        expect(child).to.be.an('object');
-        expect(child.parent()).to.equal(group);
-      });
-      // child marks will all have the same ID "undefined"...
-      // expect(group.marks.length).to.equal(3);
-      expect(group.axes.length).to.equal(1);
-      expect(group.legends.length).to.equal(1);
-    });
-
-    it('throws an error if provided an invalid type', function() {
-      expect(function() {
-        group.child('unsupported primitive');
-      }).to.throw;
-    });
-
-    it('can insert a pre-existing primitive into a group', function() {
-      var otherGroup = new Group();
-      expect(otherGroup.parent()).not.to.equal(group);
-      group.child('marks.group', otherGroup);
-      expect(otherGroup.parent()).to.equal(group);
-    });
-
-  });
-
-  describe('remove child method', function() {
-
-    beforeEach(function() {
-      group = new Group();
-      // Shim to handle the ID binding that no longer occurs in Mark instances
-      group._id = 1;
-      model.primitive(group._id, group);
-      subgroup = new Group();
-      subgroup._id = 2;
-      model.primitive(subgroup._id, subgroup);
-      group.child('marks.group', subgroup);
-    });
-
-    it('is a function', function() {
-      expect(group).to.have.property('removeChild');
-      expect(group.child).to.be.a('function');
-    });
-
-    it('it removes the mark id from this.marks array', function() {
-      // delete group
-      var subgroupId = subgroup._id;
-      group.removeChild(subgroupId);
-
-      expect(group.marks.length).to.equal(0);
-    });
-
-    it('if child mark is a group, it recursively removes the grandchildren', function() {
-      var subsub = new Group();
-      subsub._id = 3;
-      model.primitive(subsub._id, subsub);
-      subgroup.child('marks.group', subsub);
-      var subgroupId = subgroup._id;
-      // make sure these are being instantiated and exist
-      expect(group.marks.length).to.equal(1);
-      expect(subgroup.marks.length).to.equal(1);
-      // remove parent group
-      group.removeChild(subgroupId);
-      // make sure they are removed
-      expect(group.marks.length).to.equal(0);
-      expect(subgroup.marks.length).to.equal(0);
-    });
-
-  });
-
-  describe('remove children method', function() {
-
-    it('is a function', function() {
-      expect(group).to.have.property('removeChildren');
-      expect(group.child).to.be.a('function');
-    });
-
-    it('if type is "marks" removes all references of children ids', function() {
-      group = new Group();
-      group._id = 1;
-      model.primitive(group._id, group);
-      subgroup = new Group();
-      subgroup._id = 2;
-      model.primitive(subgroup._id, subgroup);
-      group.child('marks.group', subgroup);
-      [new Group(), new Group(), new Group()].forEach(function(childGroup, idx) {
-        childGroup._id = idx + 3;
-        model.primitive(childGroup._id, childGroup);
-        group.child('marks.group', childGroup);
-      });
-      // make sure children are being instantiated and exist
-      expect(group.marks.length).to.to.equal(4);
-      group.removeChildren('marks');
-      expect(group.marks.length).to.to.equal(0);
-    });
-  });
 });

--- a/src/js/model/primitives/marks/Mark.js
+++ b/src/js/model/primitives/marks/Mark.js
@@ -11,6 +11,7 @@ var dl = require('datalib'),
     propSg = require('../../../util/prop-signal'),
     model = require('../../'),
     lookup = model.lookup,
+    getParent = require('../../../util/hierarchy').getParent,
     counter = require('../../../util/counter');
 
 /**
@@ -161,7 +162,7 @@ Mark.prototype.dataset = function(id) {
   var from;
   if (!arguments.length) {
     from = lookup(this.from);
-    return from && lookup(from.parent()._id);
+    return from && lookup(getParent(from)._id);
   } else if ((from = lookup(id)) instanceof Dataset) {
     this.from = id;
     return this;

--- a/src/js/model/primitives/marks/Scene.test.js
+++ b/src/js/model/primitives/marks/Scene.test.js
@@ -7,7 +7,6 @@ var Scene = require('./Scene');
 var Group = require('./Group');
 var Mark = require('./Mark');
 var VLSingle = require('../../rules/VLSingle');
-var model = require('../../');
 
 describe('Scene Mark', function() {
   var scene;
@@ -182,54 +181,6 @@ describe('Scene Mark', function() {
       expect(scene).to.have.property('_rule');
       expect(scene._rule).to.be.an('object');
       expect(scene._rule).to.be.an.instanceOf(VLSingle);
-    });
-
-  });
-
-  describe('child method', function() {
-
-    beforeEach(function() {
-      scene = new Scene();
-      // Shim to handle the ID binding that no longer occurs in Mark instances
-      scene._id = 1;
-      model.primitive(scene._id, scene);
-    });
-
-    it('is a function', function() {
-      expect(scene).to.have.property('child');
-      expect(scene.child).to.be.a('function');
-    });
-
-    it('creates and returns child primitives within the scene', function() {
-      [
-        'axes',
-        'legends',
-        'marks.group',
-        'marks.rect',
-        'marks.symbol'
-      ].forEach(function(primitiveType) {
-        var child = scene.child(primitiveType);
-        expect(child).to.be.an('object');
-        expect(child.parent()).to.equal(scene);
-      });
-    });
-
-    it('creates a scale but does not assign itself as parent', function() {
-      var scale = scene.child('scales');
-      expect(scale.parent).to.be.null;
-    });
-
-    it('throws an error if provided an invalid type', function() {
-      expect(function() {
-        scene.child('unsupported primitive');
-      }).to.throw;
-    });
-
-    it('can insert a pre-existing primitive into a scene', function() {
-      var otherGroup = new Group();
-      expect(otherGroup.parent()).not.to.equal(scene);
-      scene.child('marks.scene', otherGroup);
-      expect(otherGroup.parent()).to.equal(scene);
     });
 
   });

--- a/src/js/model/rules/data.js
+++ b/src/js/model/rules/data.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var getParent = require('../../util/hierarchy').getParent;
+
 /**
  * Parse the data source definitions in the resultant Vega specification.
  * For now, as we do not yet support transforms, we only add an entry to the
@@ -16,7 +18,7 @@ function data(parsed, from) {
   var map = this._rule._map.data;
   // This is a super-simple map to map b/w names in the vega output
   // VL's data[0].name.source maps to something in lyra e.g.
-  map.source = from.parent()._source._id;
+  map.source = getParent(from)._source._id;
 }
 
 module.exports = data;

--- a/src/js/model/rules/guides.js
+++ b/src/js/model/rules/guides.js
@@ -5,6 +5,7 @@ var dl = require('datalib'),
     getGuideScale = require('../../util/store-utils').getGuideScale,
     addAxisToGroup = require('../../actions/ruleActions').addAxisToGroup,
     addLegendToGroup = require('../../actions/ruleActions').addLegendToGroup,
+    getParent = require('../../util/hierarchy').getParent,
     model = require('../'),
     lookup = model.lookup;
 
@@ -32,7 +33,7 @@ var SWAP_ORIENT = {
  */
 function findOrCreateAxis(scale, defs) {
   var map = this._rule._map.scales,
-      axes = this.parent().axes,
+      axes = getParent(this).axes,
       axisDef = defs.find(function(def) {
         return map[def.scale] === scale._id;
       }),
@@ -76,7 +77,7 @@ function findOrCreateAxis(scale, defs) {
  */
 function findOrCreateLegend(scale, defs, property) {
   var map = this._rule._map.scales,
-      legends = this.parent().legends,
+      legends = getParent(this).legends,
       legendDef = defs.find(function(d) {
         return map[d[property]] === scale._id;
       }),

--- a/src/js/model/rules/index.js
+++ b/src/js/model/rules/index.js
@@ -5,6 +5,7 @@ var dl = require('datalib'),
     Scale = require('../primitives/Scale'),
     model = require('../'),
     lookup = model.lookup,
+    getParent = require('../../util/hierarchy').getParent,
     AGG_OPS = vg.transforms.aggregate.VALID_OPS;
 
 // Pull in the modules which will be assembled into the rules namespace
@@ -100,7 +101,7 @@ function compile(rule, property, from) {
   // We analyze the resultant Vega spec to understand what this mark's
   // backing dataset should actually be (source, aggregate, etc.).
   if (from) {
-    rule.data.values = from.parent()._source.output();
+    rule.data.values = getParent(from)._source.output();
   }
 
   // Hack the config to be able to differentiate height/width for
@@ -162,7 +163,7 @@ function rules(prototype) {
     }
 
     // obj instanceof Field
-    if (from && from.parent() !== obj.parent().parent()) {
+    if (from && getParent(from) !== getParent(getParent(obj))) {
       throw Error("Mark's backing pipeline differs from field's.");
     }
 
@@ -175,7 +176,7 @@ function rules(prototype) {
     }
 
     rule.encoding[c] = channelDef(obj);
-    from = from || obj.parent();
+    from = from || getParent(obj);
 
     // Hand off to VL to compile
     var parsed = compile.call(this, rule, property, from);

--- a/src/js/util/hierarchy.js
+++ b/src/js/util/hierarchy.js
@@ -12,30 +12,6 @@ function getParent(mark) {
 }
 
 /**
- * Return all child primitives of the provided group.
- *
- * @param {Group} groupMark - The group for which to return children
- * @returns {Object[]} Array of instantiated primitive objects that are children
- * of the provided group mark
- */
-function getChildren(groupMark) {
-  // Require model in here to sidestep circular dependency issue
-  var lookup = require('../model').lookup;
-
-  return ['scales', 'legends', 'axes', 'marks'].reduce(function(allChildren, childType) {
-    if (!groupMark[childType]) {
-      return allChildren;
-    }
-    return allChildren.concat(groupMark[childType].map(function(childId) {
-      return lookup(childId);
-    }));
-  }, []).filter(function(mark) {
-    // Filter out any null or undefined results, in case an invalid ID is present
-    return !!mark;
-  });
-}
-
-/**
  * Get all parent nodes for a given primitive in the Lyra hierarchy, i.e. all
  * groups which may be considered to be ancestors of the provided primitive.
  *
@@ -119,7 +95,6 @@ function findInItemTree(item, path) {
 
 module.exports = {
   getParent: getParent,
-  getChildren: getChildren,
   getParentGroupIds: getParentGroupIds,
   getParents: getParents,
   getGroupIds: getGroupIds,

--- a/src/js/util/hierarchy.test.js
+++ b/src/js/util/hierarchy.test.js
@@ -23,10 +23,12 @@ describe('hierarchy utilities', function() {
 
     it('returns the parent of a provided mark', function() {
       var parent = new Group();
-      // Shim to handle the ID binding that no longer occurs in Mark instances
+      // Set up a parent hierarchy to test
       parent._id = 1;
       model.primitive(parent._id, parent);
-      var rect = parent.child('marks.rect');
+      var rect = new Rect();
+      rect._parent = parent._id;
+      parent.marks.push(rect._id);
       expect(getParent(rect)).to.equal(parent);
     });
 
@@ -34,53 +36,6 @@ describe('hierarchy utilities', function() {
       var parentlessMark = new Rect(),
           result = getParent(parentlessMark);
       expect(result).to.be.null;
-    });
-
-  });
-
-  describe('getChildren', function() {
-    var getChildren, group;
-
-    beforeEach(function() {
-      getChildren = hierarchy.getChildren;
-      group = new Group();
-      group._id = 1;
-      model.primitive(group._id, group);
-    });
-
-    it('is a function', function() {
-      expect(getChildren).to.be.a('function');
-    });
-
-    it('returns an empty array for childless groups', function() {
-      var result = getChildren(group);
-      expect(result).to.deep.equal([]);
-    });
-
-    it('returns an array of all children of the provided group', function() {
-      var child1 = group.child('scales'),
-          child2 = group.child('axes'),
-          child3 = group.child('marks.group'),
-          child4 = group.child('marks.rect');
-      [child3, child4].forEach(function(mark, idx) {
-        // Shim to handle the ID binding that no longer occurs in Mark instances
-        mark._id = idx;
-        model.primitive(idx, mark);
-        group.marks.push(mark._id);
-      });
-      expect(getChildren(group)).to.deep.equal([child1, child2, child3, child4]);
-    });
-
-    it('omits invalid IDs from the returned array', function() {
-      group.marks.push('invalidID1', 'invalidID2');
-      var result = getChildren(group);
-      expect(result).to.deep.equal([]);
-    });
-
-    it('returns an empty array for non-group marks', function() {
-      var rect = new Rect(),
-          result = getChildren(rect);
-      expect(result).to.deep.equal([]);
     });
 
   });
@@ -121,13 +76,18 @@ describe('hierarchy utilities', function() {
           g3 = new Group(),
           rect = new Rect(),
           result;
-      // Shim to handle the ID binding that no longer occurs in Mark instances
+      // Set up a parent hierarchy to test
       [g1, g2, g3, rect].reduce(function(parentMark, childMark, idx) {
-        // Set up the child mark propertly
+        // Set up the child mark
         childMark._id = idx + 1;
         model.primitive(childMark._id, childMark);
-        // Set this mark a child of the last; then child is the new parent
-        return parentMark ? parentMark.child('marks', childMark) : childMark;
+        // Set this mark a child of the last;
+        if (parentMark) {
+          childMark._parent = parentMark._id;
+          parentMark.marks.push(childMark._id);
+        }
+        // then child is the new parent
+        return childMark;
       }, null);
 
       result = getParents(rect);
@@ -187,13 +147,18 @@ describe('hierarchy utilities', function() {
           g3 = new Group(),
           rect = new Rect(),
           result;
-      // Shim to handle the ID binding that no longer occurs in Mark instances
+      // Set up a parent hierarchy to test
       [g1, g2, g3, rect].reduce(function(parentMark, childMark, idx) {
-        // Set up the child mark propertly
+        // Set up the child mark
         childMark._id = idx + 1;
         model.primitive(childMark._id, childMark);
-        // Set this mark a child of the last; then child is the new parent
-        return parentMark ? parentMark.child('marks', childMark) : childMark;
+        // Set this mark a child of the last;
+        if (parentMark) {
+          childMark._parent = parentMark._id;
+          parentMark.marks.push(childMark._id);
+        }
+        // then child is the new parent
+        return childMark;
       }, null);
 
       result = getParentGroupIds(rect);


### PR DESCRIPTION
**Description of the problem this pull request fixes**

`Group.prototype.child` was deprecated last week; now that Redux is meant to be the source of truth for marks, the proper way to manage hierarchy is to dispatch a `setParent` action or take some related action that lets the reducer handle setting the `.marks` and `._parent` properties used to manage the hierarchy of Lyra primitives.

If `.child()` is no more, then related utilities like `getChildren` (which was written provisionally, then never used) can also be removed; and at that point it seemed best to remove `Primitive.prototype.parent` as well, in favor of always using the `getParent` utility method.

In areas where `.parent()` was being used to set parent on assignment (via the construct `result = new Constructor(args).parent(parentId)`), I have added `_parent` as an optional propery to the relevant constructor so that the value can be set in one statement without needing to chain any method calls together.

**Changes proposed in this pull request:**
- Remove `Group.prototype.child`
- Re-write hierarchy test setup code to avoid needing `.child` method
- Use `getParent` utility in place of `.parent()` prototype method
- Remove `Primitive.prototype.parent`
- Augment constructors still outside of Redux's purview to accept a `_parent` ID value when necessary
- Remove unused `hierarchy.getChildren` utility

**This PR includes:**
- [x] Tests
- [x] functional comments

**Steps to functionally test this:**
- Functional test: Did anything break?
