### PR TITLE
scene spec not returning height & width

### DIFF
--- a/src/js/actions/createScene.js
+++ b/src/js/actions/createScene.js
@@ -11,13 +11,14 @@ var counter = require('../util/counter');
  * Loading data will require adding an action or altering this action to permit
  * seeding the created scene with preexisting properties.
  *
+ * @param {Object} customProps - custom properties
  * @returns {Object} An action object
  */
-module.exports = function() {
+module.exports = function(customProps) {
   var Scene = require('../model/primitives/marks/Scene');
-  var props = Scene.defaultProperties({
-    _id: counter.global()
-  });
+  var properties = customProps || {};
+  properties._id = counter.global();
+  var props = Scene.defaultProperties(properties);
 
   return {
     type: CREATE_SCENE,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,10 @@ store.subscribe(listeners.createStoreListener(store, model));
 
 // Initializes the Lyra model with a new Scene primitive.
 var createScene = require('./actions/createScene');
-store.dispatch(createScene());
+store.dispatch(createScene({
+  width: 600,
+  height: 600
+}));
 
 // Initialize components
 var ui = require('./components');

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -1,11 +1,9 @@
 'use strict';
 var dl = require('datalib'),
     inherits = require('inherits'),
-    sg = require('../../signals'),
-    Group = require('./Group');
-
-var SG_WIDTH = 'vis_width',
-    SG_HEIGHT = 'vis_height';
+    Group = require('./Group'),
+    store = require('../../../store'),
+    getIn = require('../../../util/immutable-utils').getIn;
 
 /**
  * @classdesc A Lyra Scene Primitive.
@@ -38,6 +36,7 @@ Scene.prototype.parent = null;
  * @returns {Object} The default mark properties
  */
 Scene.defaultProperties = function(props) {
+  console.log(props);
   // Note that scene has no "properties" property
   return dl.extend({
     // Containers for child marks
@@ -66,8 +65,10 @@ Scene.prototype.export = function(resolve) {
   var spec = Group.prototype.export.call(this, resolve);
 
   // Always resolve width/height signals.
-  spec.width = spec.width.signal ? sg.get(SG_WIDTH) : spec.width;
-  spec.height = spec.height.signal ? sg.get(SG_HEIGHT) : spec.height;
+  spec.width = spec.width.signal ?
+                getIn(store.getState(), 'signals.' + spec.width.signal + '.init') : spec.width;
+  spec.height = spec.height.signal ?
+                getIn(store.getState(), 'signals.' + spec.height.signal + '.init') : spec.height;
 
   // Remove mark-specific properties
   delete spec.type;

--- a/src/js/model/primitives/marks/Scene.test.js
+++ b/src/js/model/primitives/marks/Scene.test.js
@@ -184,5 +184,22 @@ describe('Scene Mark', function() {
     });
 
   });
+  describe('scene export', function() {
+    var spec;
+    beforeEach(function() {
+      scene = new Scene();
+      spec = scene.export();
+    });
+
+    it('width exists on the spec and is not undefined', function() {
+      expect(spec).to.have.property('width');
+      expect(spec.width).to.not.be.undefined;
+    });
+
+    it('height exists on the spec and is not undefined', function() {
+      expect(spec).to.have.property('height');
+      expect(spec.height).to.not.be.undefined;
+    });
+  });
 
 });

--- a/src/js/reducers/marks.test.js
+++ b/src/js/reducers/marks.test.js
@@ -208,7 +208,6 @@ describe('marks reducer', function() {
         signal: 'lyra_vis_width'
       });
     });
-
   });
 
   describe('set parent action', function() {

--- a/src/js/reducers/signals.test.js
+++ b/src/js/reducers/signals.test.js
@@ -249,6 +249,26 @@ describe('signals reducer', function() {
           _idx: 1
         }
       });
+    });
+
+    it('initializes the scene width & height signals set to custom values', function() {
+      var result = signalsReducer(initialState,
+      createScene({
+        width: 400,
+        height: 100
+      }));
+      expect(result.toJS()).to.deep.equal({
+        lyra_vis_width: {
+          name: 'lyra_vis_width',
+          init: 400,
+          _idx: 0
+        },
+        lyra_vis_height: {
+          name: 'lyra_vis_height',
+          init: 100,
+          _idx: 1
+        }
+      });
 
     });
 


### PR DESCRIPTION
**Description of the problem this pull request fixes**
I noticed this happening in the UI when I added a new group to the scene and decided to investigate:
![wat](https://cloud.githubusercontent.com/assets/607541/14537594/7b7242aa-022c-11e6-905c-47431a6a1558.gif)

Turns out that the way the signals were added to the scene in the reducer was breaking setting the width/height.

I removed that and also updated the scene action and reducer (and tests) to let you initialize with new properties.  It currently wouldn't let you do that.

I also added a test to make sure that height and width always returned for scene when exporting.

![wat2](https://cloud.githubusercontent.com/assets/607541/14537666/c798b54c-022c-11e6-8220-0111e7559b23.gif)
You can see a tiny jump because of the padding in the scene, but it's not as drastic as it was before.

**This PR includes:**
- [x] Tests
