### PR TITLE
fix clean function so it uses redux

### DIFF
--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var dl = require('datalib'),
-    sg = require('../signals'),
+    store = require('../../store'),
+    getIn = require('../../util/immutable-utils').getIn,
     model = require('../'),
     counter = require('../../util/counter');
 
@@ -31,7 +32,9 @@ function _clean(spec, clean) {
     if (c) {
       delete spec[k];
     } else if (dl.isObject(p)) {
-      spec[k] = p.signal && cln ? sg.get(p.signal) : _clean(spec[k], clean);
+      spec[k] = p.signal && cln ?
+      getIn(store.getState(), 'signals.' + p.signal + '.init') :
+      _clean(spec[k], clean);
     }
   }
 


### PR DESCRIPTION
**Description of the problem this pull request fixes**
When running model.export() it wasn't replacing the signal values in the clean function because it was still using sg()

I need this in for the validation stuff for walkthroughs. 

I know this is bad form and this should absolutely have a test, but can we merge it without a test maybes?
