### PR TITLE
signal lookup utility and test

### DIFF
--- a/src/js/model/primitives/Primitive.js
+++ b/src/js/model/primitives/Primitive.js
@@ -2,8 +2,7 @@
 'use strict';
 
 var dl = require('datalib'),
-    store = require('../../store'),
-    getIn = require('../../util/immutable-utils').getIn,
+    signalLookup = require('../../util/signal-lookup'),
     model = require('../'),
     counter = require('../../util/counter');
 
@@ -32,9 +31,7 @@ function _clean(spec, clean) {
     if (c) {
       delete spec[k];
     } else if (dl.isObject(p)) {
-      spec[k] = p.signal && cln ?
-      getIn(store.getState(), 'signals.' + p.signal + '.init') :
-      _clean(spec[k], clean);
+      spec[k] = p.signal && cln ? signalLookup(p.signal) : _clean(spec[k], clean);
     }
   }
 

--- a/src/js/model/primitives/marks/Scene.js
+++ b/src/js/model/primitives/marks/Scene.js
@@ -2,8 +2,7 @@
 var dl = require('datalib'),
     inherits = require('inherits'),
     Group = require('./Group'),
-    store = require('../../../store'),
-    getIn = require('../../../util/immutable-utils').getIn;
+    signalLookup = require('../../../util/signal-lookup');
 
 /**
  * @classdesc A Lyra Scene Primitive.
@@ -65,9 +64,9 @@ Scene.prototype.export = function(resolve) {
 
   // Always resolve width/height signals.
   spec.width = spec.width.signal ?
-                getIn(store.getState(), 'signals.' + spec.width.signal + '.init') : spec.width;
+                signalLookup(spec.width.signal) : spec.width;
   spec.height = spec.height.signal ?
-                getIn(store.getState(), 'signals.' + spec.height.signal + '.init') : spec.height;
+                signalLookup(spec.height.signal) : spec.height;
 
   // Remove mark-specific properties
   delete spec.type;

--- a/src/js/util/signal-lookup.js
+++ b/src/js/util/signal-lookup.js
@@ -1,0 +1,13 @@
+'use strict';
+var store = require('../store'),
+    getIn = require('./immutable-utils').getIn
+
+/**
+ * Retrieves the value stored in redux for the signal
+ *
+ * @param {string} signal - The name of the signal
+ * @returns {string|number|object} returns what is stored in redux which could be one of these types
+ */
+module.exports = function(signal) {
+  return getIn(store.getState(), 'signals.' + signal + '.init');
+};

--- a/src/js/util/signal-lookup.test.js
+++ b/src/js/util/signal-lookup.test.js
@@ -1,0 +1,20 @@
+/* eslint no-unused-expressions:0 */
+'use strict';
+var expect = require('chai').expect,
+    signal = require('../model/signals'),
+    signalLookup = require('./signal-lookup');
+
+describe('Signal Lookup utility', function() {
+  beforeEach(function(){
+    signal.init('lyra_rect_29_fill', '#4682b4');
+  });
+
+  it('is a function', function() {
+    expect(signalLookup).to.be.a('function');
+  });
+
+  it('returns a the value in the store for a specific signal property', function() {
+    expect(signalLookup('lyra_rect_29_fill')).to.equal('#4682b4');
+  });
+
+});


### PR DESCRIPTION
Adding a utility to retrieve values out of the store.
We were using the same code in Scene.js and Primitive.js to look up values, I pulled it out into a utility, so it's less.... wordy.

**This PR includes:**
- [x] Tests
- [x] functional comments
- [x] high level description of any new components

**Steps to functionally test this:**
- check that the scene is not 500 x 500

The area where it replaces code in Primitive is for the export function which we don't currently have hooked up to the ui.  You can still look at it in the console by running `model.export()` and making sure the values are returning instead of the signal names in the object.

![screen shot 2016-04-18 at 8 56 19 am](https://cloud.githubusercontent.com/assets/607541/14610602/7e351818-0543-11e6-8302-cf74595def6d.png)
