### PR TITLE
imperfect fix for drag and drop in firefox

### DIFF
--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -83,6 +83,7 @@ var DataTable = React.createClass({
   },
 
   handleDragStart: function(evt) {
+    evt.dataTransfer.setData('text/plain', '');
     sg.set(sg.MODE, 'channels');
     model.update();
   },


### PR DESCRIPTION
I don't want to spend a lot of time troubleshooting every part of this, so here's what I got.  Drag and drop works now.  The ghost element does not look right.

Soo fun.
