### PR TITLE
deleteUpdate is not being used, breaks in UI branch

### DIFF
--- a/src/js/components/InspectorSidebar.jsx
+++ b/src/js/components/InspectorSidebar.jsx
@@ -29,9 +29,10 @@ var Inspector = React.createClass({
   render: function() {
     var props = this.props,
         // props.id existence check handles the initial application render
-        primitive = props.id ? lookup(props.id) : {},
-        from = lookup(primitive.from),
-        ctor = primitive.constructor.name,
+        primitive = props.id ? lookup(props.id) : {};
+
+    var from = primitive ? lookup(primitive.from) : '',
+        ctor = primitive ? primitive.constructor.name : '',
         InspectorType = Inspector[ctor],
         isMark = primitive instanceof Mark;
 

--- a/src/js/components/visualization/GroupSubMenu.jsx
+++ b/src/js/components/visualization/GroupSubMenu.jsx
@@ -71,7 +71,8 @@ var Group = React.createClass({
   },
 
   icon: function(type, expanded) {
-    var gtype = type + (type === 'group' ? expanded ? '-open' : '-closed' : ''),
+    var expandedSubClass = expanded ? '-open' : '-closed',
+        gtype = type + (type === 'group' ? expandedSubClass : ''),
         glyph = assets[gtype],
         click = type === 'group' ? this.props.toggle.bind(null, this.props.id) : null,
         iconMarkup = (<Icon glyph={glyph} onClick={click} />);
@@ -80,11 +81,9 @@ var Group = React.createClass({
 
   deleteUpdate: function(id) {
     ReactTooltip.hide();
-    this.deleteMark(id);
+    this.props.deleteMark(id);
     // set selected to null
     this.props.select(null);
-    // redraw sidebar
-    this.updateSidebar();
   },
 
   render: function() {


### PR DESCRIPTION
This fixes an issue with delete marks in the sidebar.  I think one of our many rebases might have messed this up.

The issue was you could not delete a mark inside a group. Also deleting a group or mark would cause a lot of console errors.

Also removed a nested ternary operator I should have caught in the UI branch. SHAME ON ALL OF US. 

To test this, delete a lot of things. 
