### PR TITLE
hacky pipelines fix

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,9 +27,6 @@ store.dispatch(createScene({
   height: 600
 }));
 
-// Initialize components
-var ui = require('./components');
-
 var p = model.pipeline('cars'),
     p2 = model.pipeline('jobs'),
     p3 = model.pipeline('gapminder');
@@ -39,7 +36,9 @@ Promise.all([
   p2._source.init({url: '/data/jobs.json'}),
   p3._source.init({url: '/data/gapminder.json'})
 ]).then(function() {
-  ui.forceUpdate();
+  // Initialize components
+  var ui = require('./components');
+
 });
 
 // Expose model, store and Sidebars globally (via `window`) for debugging


### PR DESCRIPTION
PROBLEM:
Pipelines disappeared on April 12th 2016. Where did they go?!!  They disappeared because we were forceUpdating the ui after initialization, and you can't do that on a provider.
https://github.com/vega/lyra/blob/lyra2/src/js/index.js#L42

THE SOLUTION (until pipelines are in redux):
initialize the UI after the pipelines have loaded.

I have an alternate hacky solution in this branch as well:
https://github.com/deathbearbrown/lyra/tree/pipeline-fix

^ that one adds "pipelines.status" to redux, then I set the status to a boolean when things have loaded. The boolean decides whether or not to bother with calling model.pipeline() in Sidebars.jsx. 

I can PR that one too, if you want.  I toyed with a lot of things, but each one seemed hackier and hackier and screamed "just put the pipelines in redux already"
