### PR TITLE
fixes 368 issue with parent being unset after delete

### DIFF
--- a/src/js/components/toolbar/AddMarks.jsx
+++ b/src/js/components/toolbar/AddMarks.jsx
@@ -45,9 +45,7 @@ var AddMarksTool = React.createClass({
   render: function() {
     // Closest container is determined by walking up from the selected mark,
     // otherwise it defaults to the scene itself
-    var closestContainerId = this.props.selectedId ?
-      getClosestGroupId(store.getState(), this.props.selectedId) :
-      this.props.sceneId;
+    var closestContainerId = getClosestGroupId(store.getState(), this.props.selectedId);
 
     return (
       <ul>

--- a/src/js/util/store-utils.js
+++ b/src/js/util/store-utils.js
@@ -23,7 +23,7 @@ function getClosestGroupId(state, id) {
       mark = markState && markState.toJS();
 
   if (!mark) {
-    return null;
+    return getIn(state, 'scene.id');
   }
 
   // If mark is a group or scene, return it as-is

--- a/src/js/util/store-utils.test.js
+++ b/src/js/util/store-utils.test.js
@@ -17,6 +17,9 @@ describe('store utilities', function() {
     beforeEach(function() {
       getClosestGroupId = storeUtils.getClosestGroupId;
       store = Immutable.fromJS({
+        scene: {
+          id: 1
+        },
         marks: {
           '1': {_id: 1, type: 'scene'},
           '2': {_id: 2, _parent: 1, type: 'group'},
@@ -31,9 +34,9 @@ describe('store utilities', function() {
       expect(getClosestGroupId).to.be.a('function');
     });
 
-    it('returns null if an invalid ID is specified', function() {
+    it('returns scene id if an invalid ID is specified', function() {
       var result = getClosestGroupId(store, 600);
-      expect(result).to.equal(null);
+      expect(result).to.equal(1);
     });
 
     it('returns the same ID if the provided ID represents a scene', function() {


### PR DESCRIPTION
**Description of the problem this pull request fixes**
Fixes issue #368

Changes proposed in this pull request:
- add a check to see if the parent being passed is null and select sceneid
- bind `this` to the toolbar's addMark function

**Steps to functionally test this:**
- Add 2 marks to the scene 
- delete one of the marks
- add a new mark to the scene
  - you should see the mark show up on the canvas and in the visualization's sidebar
