### PR TITLE
use primitive.type instead of contructor.name

### DIFF
--- a/src/js/components/InspectorSidebar.jsx
+++ b/src/js/components/InspectorSidebar.jsx
@@ -26,13 +26,20 @@ var Inspector = React.createClass({
     id: React.PropTypes.number,
     name: React.PropTypes.string
   },
+
+  uppercase: function(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  },
+
   render: function() {
     var props = this.props,
         // props.id existence check handles the initial application render
         primitive = props.id ? lookup(props.id) : {};
 
     var from = primitive ? lookup(primitive.from) : '',
-        ctor = primitive ? primitive.constructor.name : '',
+        ctor = primitive && primitive.type ?
+               this.uppercase(primitive.type) :
+               '',
         InspectorType = Inspector[ctor],
         isMark = primitive instanceof Mark;
 
@@ -46,7 +53,6 @@ var Inspector = React.createClass({
     var inner = InspectorType ? (
       <div className="inner">
         {pipeline}
-
         <InspectorType primitive={primitive} />
       </div>) : null;
 


### PR DESCRIPTION
Fixes the issue in #373 

To test:
1. `npm run build:prod`
2. copy `build/`, `data/`, and `index.html` to a static file server
 (You might have to fix the paths in `index.html`, I did) 
3. add a mark
4. the inspector should be there

Please repeat for all marks :) 
