### PR TITLE
WIP: use redux primitives for extents

### DIFF
--- a/src/js/components/InspectorSidebar.jsx
+++ b/src/js/components/InspectorSidebar.jsx
@@ -17,7 +17,8 @@ function mapStateToProps(reduxState, ownProps) {
   return {
     id: selectedMarkId,
     // This will need to be refactored slightly once scale or guide inspectors exist
-    name: getIn(reduxState, 'marks.' + selectedMarkId + '.name')
+    name: getIn(reduxState, 'marks.' + selectedMarkId + '.name'),
+    prim: getIn(reduxState, 'marks.' + selectedMarkId)
   };
 }
 
@@ -34,7 +35,7 @@ var Inspector = React.createClass({
   render: function() {
     var props = this.props,
         // props.id existence check handles the initial application render
-        primitive = props.id ? lookup(props.id) : {};
+        primitive = props.prim && props.prim.toObject();
 
     var from = primitive ? lookup(primitive.from) : '',
         ctor = primitive && primitive.type ?

--- a/src/js/components/inspectors/ExtentProperty.jsx
+++ b/src/js/components/inspectors/ExtentProperty.jsx
@@ -22,10 +22,6 @@ var EXTENTS = {
 
 var ExtentProperty = React.createClass({
 
-  getInitialState: function() {
-    return this.extents();
-  },
-
   componentWillReceiveProps: function() {
     this.setState(this.extents());
   },
@@ -34,12 +30,13 @@ var ExtentProperty = React.createClass({
     var props = this.props,
         type = props.type,
         primitive = props.primitive,
-        update = primitive.properties.update,
+        update = primitive.properties.toObject().update.toObject(),
         extents = dl.vals(EXTENTS[type]),
         start, end;
 
     extents.forEach(function(x) {
-      var name = x.name, prop = update[name];
+      var name = x.name,
+          prop = update[name].toObject();
       if (prop._disabled) {
         return;
       } else if (!start) {
@@ -54,10 +51,10 @@ var ExtentProperty = React.createClass({
 
   handleChange: function(evt) {
     var props = this.props,
-        state = this.state,
+        state = this.extents(),
         type = props.type,
         primitive = props.primitive,
-        update = primitive.properties.update,
+        update = primitive.properties.toObject().update.toObject(),
         target = evt.target,
         name = target.name,
         value = target.value,
@@ -80,16 +77,17 @@ var ExtentProperty = React.createClass({
   },
 
   render: function() {
-    var state = this.state,
+    var state = this.extents(),
         props = this.props,
         type = props.type,
         primitive = props.primitive,
-        update = primitive.properties.update,
+        update = primitive.properties.toObject().update.toObject(),
         extents = EXTENTS[type],
         center = extents.center.name,
         span = extents.span.label,
         opts = dl.vals(extents),
-        start = state.start, end = state.end;
+        start = state.start,
+        end = state.end;
 
     return (
       <div>

--- a/src/js/components/inspectors/SpatialPreset.jsx
+++ b/src/js/components/inspectors/SpatialPreset.jsx
@@ -15,7 +15,7 @@ var SpatialPreset = React.createClass({
         primitive = props.primitive,
         target = evt.target,
         name = target.name,
-        update = primitive.properties.update,
+        update = primitive.properties.toObject().update.toObject(),
         prop = update[name],
         scale = prop.scale && lookup(prop.scale),
         preset = name.indexOf('x') >= 0 ? 'width' : 'height';
@@ -40,7 +40,7 @@ var SpatialPreset = React.createClass({
     var props = this.props,
         name = props.name,
         primitive = this.props.primitive,
-        update = primitive.properties.update,
+        update = primitive.properties.toObject().update.toObject(),
         prop = update[name],
         scale = prop.scale && lookup(prop.scale),
         preset = name.indexOf('x') >= 0 ? 'width' : 'height';


### PR DESCRIPTION
Problem:

> One functional bug I've noticed: if I drag out a rect mark and then some ordinal data (e.g., gapminder > country) to x for example, the inspector updates to show the scale/field for "left", but "right" doesn't update to "width" and automatic.
> ![](https://cloud.githubusercontent.com/assets/42262/15890760/71762832-2d71-11e6-8b60-6ec62f41e075.png)

@arvind  can you please test branch and just check that I actually fixed this bug?  I think something might still be wonky. 
