### PR TITLE
Feature allows user to change the mtype (nominal, quantitative, and t…

### DIFF
--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -155,7 +155,7 @@ var DataTable = React.createClass({
 
   handleMTYPEChangeClick: function(evt) {
     var newFullField = this.state.fullField;
-    const MTYPES = dsUtil.MTYPES;
+    var MTYPES = dsUtil.MTYPES;
     var mtypeIndex = -1;
     MTYPES.forEach(function (currentValue, index, array) {
       if(currentValue == newFullField.mtype) {

--- a/src/js/components/pipelines/DataTable.jsx
+++ b/src/js/components/pipelines/DataTable.jsx
@@ -153,6 +153,21 @@ var DataTable = React.createClass({
     return false;
   },
 
+  handleMTYPEChangeClick: function(evt) {
+    var newFullField = this.state.fullField;
+    const MTYPES = dsUtil.MTYPES;
+    var mtypeIndex = -1;
+    MTYPES.forEach(function (currentValue, index, array) {
+      if(currentValue == newFullField.mtype) {
+          mtypeIndex = index;
+      }
+    });
+    mtypeIndex = (mtypeIndex + 1) % MTYPES.length;
+    newFullField.mtype = MTYPES[mtypeIndex];
+
+    this.setState({fullField: newFullField});
+  },
+
   render: function() {
     var state = this.state,
         props = this.props,
@@ -183,7 +198,8 @@ var DataTable = React.createClass({
 
     fullField = fullField ? (
       <span>
-        <Icon glyph={assets[fullField.mtype]} width="10" height="10" /> {fullField.name}
+        <Icon onClick={this.handleMTYPEChangeClick}
+          glyph={assets[fullField.mtype]} width="10" height="10" /> {fullField.name}
       </span>
       ) : null;
 

--- a/src/js/util/dataset-utils.js
+++ b/src/js/util/dataset-utils.js
@@ -109,4 +109,6 @@ du.reset = function() {
   schema = {};
 };
 
+du.MTYPES = ['nominal', 'quantitative', 'temporal']; // ordinal not yet used
+
 module.exports = du;


### PR DESCRIPTION
**Description of the problem this pull request fixes**
Feature allows user to change the mtype (nominal, quantitative, and temporal) when user clicks icon in the first column of each row of the datatable in the datapipeline section. 

Changes proposed in this pull request:
- added mtypes constant to the exported object in dataset-utils
- feature to toggle between mtypes

*\* If submitting code for review: **

**This PR includes:**
- [ ] Tests
- [ ] functional comments
- [ ] high level description of any new components

**Steps to functionally test this:**
- Open up data table in the Data Pipelines section
## \- Click on icon in the first column of any row to see icon toggle between the various mtypes.

…emporal) when click icon in the first column of each row of the datatable in the datapipeline. Also added mtypes constant to the exported object in dataset-utils
