### PR TITLE
Don’t repeat vendor dependencies in lyra bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
   },
   plugins: [
     // Render CSS out into a separate file
-    new ExtractTextPlugin('style.css')
+    new ExtractTextPlugin('style.css'),
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'js/vendor.js')
   ]
 };


### PR DESCRIPTION
Before

```
           Asset      Size  Chunks             Chunk Names
      js/lyra.js   2.99 MB       0  [emitted]  lyra
    js/vendor.js   2.12 MB       1  [emitted]  vendor
       style.css   18.4 kB       0  [emitted]  lyra
  js/lyra.js.map   3.54 MB       0  [emitted]  lyra
   style.css.map  86 bytes       0  [emitted]  lyra
js/vendor.js.map   2.44 MB       1  [emitted]  vendor
```

after

```
           Asset       Size  Chunks             Chunk Names
      js/lyra.js     825 kB       0  [emitted]  lyra
    js/vendor.js    2.27 MB       1  [emitted]  vendor
       style.css    18.4 kB       0  [emitted]  lyra
  js/lyra.js.map     961 kB       0  [emitted]  lyra
   style.css.map  857 bytes       0  [emitted]  lyra
js/vendor.js.map    2.67 MB       1  [emitted]  vendor
```
