### PR TITLE
Convert guide property values to signals.

### DIFF
--- a/src/js/actions/markActions.js
+++ b/src/js/actions/markActions.js
@@ -62,7 +62,7 @@ function deleteMark(id) {
       type: DELETE_MARK,
       // ID and Type are needed to clear up all the mark's signals, as those are
       // the values used to create a signal's identifying name.
-      markId: mark._id,
+      id: mark._id,
       markType: mark.type
     });
 

--- a/src/js/components/inspectors/Guide.jsx
+++ b/src/js/components/inspectors/Guide.jsx
@@ -55,18 +55,16 @@ var GuideInspector = React.createClass({
             type="select" />
 
           <MoreProperties label="Axis">
-            <Property name="properties.axis.stroke.value"
+            <Property name="properties.axis.stroke"
               label="Color"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="color" />
 
-            <Property name="properties.axis.strokeWidth.value"
+            <Property name="properties.axis.strokeWidth"
               label="Width"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="range"
               min="0"
               max="10"
@@ -84,19 +82,17 @@ var GuideInspector = React.createClass({
             onChange={this.handleChange}
             type="text" />
 
-          <Property name="properties.title.fontSize.value"
+          <Property name="properties.title.fontSize"
             label="Font Size"
             primType="guides"
             primitive={primitive}
-            onChange={this.handleChange}
             type="number" />
 
           <MoreProperties label="Title">
-            <Property name="properties.title.fill.value"
+            <Property name="properties.title.fill"
               label="Color"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="color" />
 
             <Property name="titleOffset"
@@ -111,26 +107,23 @@ var GuideInspector = React.createClass({
         <div className="property-group">
           <h3>Labels</h3>
 
-          <Property name="properties.labels.fontSize.value"
+          <Property name="properties.labels.fontSize"
             label="Font Size"
             primType="guides"
             primitive={primitive}
-            onChange={this.handleChange}
             type="number" />
 
-          <Property name="properties.labels.angle.value"
+          <Property name="properties.labels.angle"
             label="Angle" min="0" max="360"
             primType="guides"
             primitive={primitive}
-            onChange={this.handleChange}
             type="number" />
 
           <MoreProperties label="Label">
-            <Property name="properties.labels.fill.value"
+            <Property name="properties.labels.fill"
               label="Fill"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="color" />
           </MoreProperties>
         </div>
@@ -154,18 +147,16 @@ var GuideInspector = React.createClass({
             type="select" />
 
           <MoreProperties label="Grid">
-            <Property name="properties.grid.stroke.value"
+            <Property name="properties.grid.stroke"
               label="Color"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="color" />
 
-            <Property name="properties.grid.strokeWidth.value"
+            <Property name="properties.grid.strokeWidth"
               label="Width"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="range"
               min="0"
               max="10"
@@ -182,18 +173,16 @@ var GuideInspector = React.createClass({
               onChange={this.handleChange}
               type="number" />
 
-            <Property name="properties.ticks.stroke.value"
+            <Property name="properties.ticks.stroke"
               label="Color"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="color" />
 
-            <Property name="properties.ticks.strokeWidth.value"
+            <Property name="properties.ticks.strokeWidth"
               label="Width"
               primType="guides"
               primitive={primitive}
-              onChange={this.handleChange}
               type="range"
               min="0"
               max="10"

--- a/src/js/components/toolbar/AddMarks.jsx
+++ b/src/js/components/toolbar/AddMarks.jsx
@@ -21,7 +21,7 @@ function mapDispatchToProps(dispatch, ownProps) {
   return {
     addMark: function(type) {
       var newMarkProps = Mark(type, {
-        _parent: getClosestGroupId(ownProps.selectedId)
+        _parent: getClosestGroupId()
       });
       dispatch(addMark(newMarkProps));
     }

--- a/src/js/components/toolbar/UndoRedo.jsx
+++ b/src/js/components/toolbar/UndoRedo.jsx
@@ -38,14 +38,12 @@ var UndoRedo = React.createClass({
     var props = this.props;
     return (
       <ul>
-        <li onClick={props.undo}>
-          <Icon glyph={assets.undo} className={'undo' + (!props.canUndo ? ' grey' : '')}
-            width="12" height="12" />
+        <li onClick={props.undo} className={!props.canUndo ? 'grey' : ''}>
+          <Icon glyph={assets.undo} className="undo" width="12" height="12" />
         </li>
 
-        <li onClick={props.redo}>
-          <Icon glyph={assets.redo} className={'redo' + (!props.canRedo ? ' grey' : '')}
-            width="12" height="12" />
+        <li onClick={props.redo} className={!props.canRedo ? 'grey' : ''}>
+          <Icon glyph={assets.redo} className="redo" width="12" height="12" />
         </li>
       </ul>
     );

--- a/src/js/reducers/guidesReducer.js
+++ b/src/js/reducers/guidesReducer.js
@@ -1,12 +1,26 @@
 /* eslint new-cap:0 */
 'use strict';
 
-var Immutable = require('immutable'),
+var dl = require('datalib'),
+    Immutable = require('immutable'),
     ACTIONS = require('../actions/Names'),
+    convertValuesToSignals = require('../util/prop-signal').convertValuesToSignals,
     immutableUtils = require('../util/immutable-utils'),
     set = immutableUtils.set,
     setIn = immutableUtils.setIn,
     deleteKeyFromMap = immutableUtils.deleteKeyFromMap;
+
+function makeGuide(action) {
+  var def = action.props,
+      props = def.properties;
+
+  return Immutable.fromJS(dl.extend({}, def, {
+    properties: Object.keys(props).reduce(function(converted, name) {
+      converted[name] = convertValuesToSignals(props[name], 'guide', action.id, name);
+      return converted;
+    }, {})
+  }));
+}
 
 function guideReducer(state, action) {
   if (typeof state === 'undefined') {
@@ -14,7 +28,7 @@ function guideReducer(state, action) {
   }
 
   if (action.type === ACTIONS.ADD_GUIDE) {
-    return set(state, action.id, Immutable.fromJS(action.props));
+    return set(state, action.id, makeGuide(action));
   }
 
   if (action.type === ACTIONS.DELETE_GUIDE) {

--- a/src/js/reducers/marksReducer.test.js
+++ b/src/js/reducers/marksReducer.test.js
@@ -144,7 +144,7 @@ describe('marks reducer', function() {
     it('nulls out the mark in the store', function() {
       var result = marksReducer(initialState, {
         type: actions.DELETE_MARK,
-        markId: 4,
+        id: 4,
         markType: 'symbol'
       });
       expect(result.get('4')).to.equal(undefined);
@@ -153,7 +153,7 @@ describe('marks reducer', function() {
     it('removes the mark from its parent\'s marks array', function() {
       var result = marksReducer(initialState, {
         type: actions.DELETE_MARK,
-        markId: 4,
+        id: 4,
         markType: 'symbol'
       });
       expect(result.get('2').toJS().marks).to.deep.equal([]);

--- a/src/js/reducers/signalsReducer.test.js
+++ b/src/js/reducers/signalsReducer.test.js
@@ -176,7 +176,7 @@ describe('signals reducer', function() {
     it('removes all signals matching the provided mark type and ID', function() {
       var result = signalsReducer(initialState, {
         type: actions.DELETE_MARK,
-        markId: 1,
+        id: 1,
         markType: 'symbol'
       });
       expect(Object.keys(result.toJS()).sort()).to.not.include.members([
@@ -189,7 +189,7 @@ describe('signals reducer', function() {
     it('does not remove any signals if no matching signal names are found', function() {
       var result = signalsReducer(initialState, {
         type: actions.DELETE_MARK,
-        markId: 1000,
+        id: 1000,
         markType: 'snake'
       });
       expect(Object.keys(result.toJS()).sort()).to.include.members([

--- a/src/js/util/hierarchy.js
+++ b/src/js/util/hierarchy.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var store = require('../store'),
-    getInVis = require('./immutable-utils').getInVis;
+    imutils = require('./immutable-utils'),
+    getIn = imutils.getIn,
+    getInVis = imutils.getInVis;
 
 /**
  * Find the parent item for a given mark.
@@ -74,7 +76,8 @@ function getParentGroupIds(markId) {
  */
 function getClosestGroupId(id) {
   var state = store.getState(),
-      markState = getInVis(state, 'marks.' + id),
+      markId = id || getIn(state, 'inspector.encodings.selectedId'),
+      markState = getInVis(state, 'marks.' + markId),
       mark = markState && markState.toJS();
 
   if (!mark) {

--- a/src/js/util/prop-signal.js
+++ b/src/js/util/prop-signal.js
@@ -1,5 +1,6 @@
 'use strict';
-var ns = require('./ns');
+var dl = require('datalib'),
+    ns = require('./ns');
 
 /**
  * Returns the signal name corresponding to the given mark and property.
@@ -8,6 +9,40 @@ var ns = require('./ns');
  * @param {string} property The name of the mark property determined by the signal.
  * @returns {string} The name of the signal for the given mark's property.
  */
-module.exports = function(markId, markType, property) {
+function propSg(markId, markType, property) {
   return ns(markType + '_' + markId + '_' + property);
-};
+}
+
+// Helper function to iterate over a mark's .properties hash and convert any .value-
+// based property definitions into appropriate signal references.
+// "properties" is the properties hash from the dispatched action; "type" is a string
+// type; and "id" is a numeric mark ID (type and ID are used to create the name of
+// the signal that will be referenced in place of values in the properties hash).
+function convertValuesToSignals(properties, type, id, propName) {
+  if (!properties) {
+    // No property values to initialize as signals; return properties as-is
+    return properties;
+  }
+
+  // Reduce the properties into a new object with all values replaced by signal
+  // references: iterate over all of the `properties.update`'s keys. For each property,
+  // replace any declared .value with a signal reference pointing at the signal which
+  // will represent that property (which should exist if the mark was instantiated
+  // properly via the addMark store action).
+  return Object.keys(properties).reduce(function(selection, key) {
+    if (selection[key] === undefined || selection[key].value === undefined) {
+      return selection;
+    }
+
+    // Replace `{value: '??'}` property definition with a ref to its controlling
+    // signal, and ensure that _disabled flags are set properly if present
+    selection[key] = dl.extend({
+      signal: propSg(id, type, propName ? propName + '_' + key : key)
+    }, selection[key]._disabled ? {_disabled: true} : {});
+
+    return selection;
+  }, properties);
+}
+
+module.exports = propSg;
+propSg.convertValuesToSignals = convertValuesToSignals;

--- a/src/scss/toolbar.scss
+++ b/src/scss/toolbar.scss
@@ -27,13 +27,6 @@
       display: flex;
       cursor: pointer;
 
-      .icon {
-        padding-right: $inner-padding;
-
-        &.undo, &.redo { padding-right: 0; }
-        &.grey { fill: #777; }
-      }
-
       ul {
         visibility: hidden;
         position: absolute;
@@ -55,6 +48,19 @@
         background-color: $lblue-bg;
 
         ul { visibility: visible; }
+      }
+
+      .icon {
+        padding-right: $inner-padding;
+
+        &.undo, &.redo { padding-right: 0; }
+      }
+
+      &.grey {
+        cursor: default;
+
+        .icon { fill: #777; }
+        &:hover { background-color: transparent; }
       }
 
       @include breakingMenus {


### PR DESCRIPTION
Like mark visual properties, this PR adds functionality to the signal and guide reducers to convert guide properties to signal references. This change will reduce the amount of spec reparsing that occurs when modifying guide visual properties. 
