### PR TITLE
Remove sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js:
   - "0.12"
   - "4.3"


### PR DESCRIPTION
`sudo:false` is not recommended  anymore https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
