### PR TITLE
Initial refactor of AutoComplete.tsx to support anon signals.

### DIFF
--- a/src/js/components/inspectors/Property.tsx
+++ b/src/js/components/inspectors/Property.tsx
@@ -6,10 +6,10 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 import { Dispatch } from 'redux';
 import {resetMarkVisual} from '../../actions/markActions';
+import {PrimType} from '../../constants/primTypes';
 import {State} from '../../store';
 import {AutoComplete} from './AutoComplete';
 import {FormInputProperty} from './FormInputProperty';
-import {PrimType} from '../../constants/primTypes';
 
 // hunch: probably actually needs to be a bunch of different types anded to a base type
 // instead of one type with everything optional

--- a/src/js/components/inspectors/Text.tsx
+++ b/src/js/components/inspectors/Text.tsx
@@ -7,11 +7,11 @@ const getInVis = require('../../util/immutable-utils').getInVis;
 import * as React from 'react';
 import {connect} from 'react-redux';
 import { Dispatch } from 'redux';
-import {updateMarkProperty} from '../../actions/markActions';
+import {setMarkVisual, updateMarkProperty} from '../../actions/markActions';
+import {PrimType} from '../../constants/primTypes';
 import {State} from '../../store';
 import {TextAlignments, TextBaselines, TextFonts, TextFontStyles, TextFontWeights} from '../../store/factory/marks/Text';
 import {Property} from './Property';
-import {PrimType} from '../../constants/primTypes';
 
 interface OwnProps {
   primId?: number;
@@ -25,7 +25,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  updateTemplate: (value: any) => void
+  updateText: (value: any) => void
 }
 
 function mapStateToProps(reduxState: State, ownProps: OwnProps): StateProps {
@@ -36,9 +36,9 @@ function mapStateToProps(reduxState: State, ownProps: OwnProps): StateProps {
 
 function mapDispatchToProps(dispatch: Dispatch, ownProps: OwnProps): DispatchProps {
   return {
-    updateTemplate: function(value) {
+    updateText: function(value) {
       const val = value.target ? value.target.value : value;
-      dispatch(updateMarkProperty({property: 'encode.update.text.template', value: val}, ownProps.primId));
+      dispatch(setMarkVisual({property: 'text', def: {signal: value}}, ownProps.primId));
     }
   };
 }
@@ -47,24 +47,14 @@ class BaseTextInspector extends React.Component<OwnProps & StateProps & Dispatch
   public render() {
     const props = this.props;
     const dsId = props.dsId;
-    const textLbl = (<h3 className='label'>Text</h3>);
-
-    const textProp = dsId ? (
-      <Property name='text.template' type='autocomplete' autoType='tmpl'
-        dsId={dsId} onChange={props.updateTemplate} {...props}>
-        {textLbl}
-      </Property>
-    ) : (
-      <Property name='text.template' type='text'
-        onChange={props.updateTemplate} {...props}>
-        {textLbl}
-      </Property>
-    );
 
     return (
       <div>
         <div className='property-group'>
-          {textProp}
+          <Property name='text.signal' type='autocomplete' autoType='tmpl'
+          dsId={dsId} onChange={props.updateText} {...props}>
+            <h3 className='label'>Text</h3>
+          </Property>
         </div>
 
         <div className='property-group'>

--- a/src/js/components/pipelines/transforms/Formula.tsx
+++ b/src/js/components/pipelines/transforms/Formula.tsx
@@ -39,7 +39,7 @@ export class Formula extends React.Component<OwnProps> {
 
     return (
       <div>
-        <Property type='autocomplete' autoType='expr' label='Calculate'
+        <Property type='autocomplete' label='Calculate'
           primType='datasets' primId={dsId} name={'transform.' + props.index + '.expr'}
           dsId={dsId} onChange={update} />
 

--- a/src/js/ctrl/export.ts
+++ b/src/js/ctrl/export.ts
@@ -167,6 +167,15 @@ exporter.mark = function(state: State, internal: boolean, id: number) {
     }
   });
 
+  // Convert text template strings into signal expressions.
+  if (spec.type === 'text') {
+    let tmpl = spec.encode.update.text.signal;
+    tmpl = tmpl.split(RegExp('{{(.*?)}}')).map(s => {
+      return s.indexOf('datum') < 0 ? `"${s}"` : `+ ${s} + `
+    }).join('');
+    spec.encode.update.text.signal = tmpl;
+  }
+
   if (internal) {
     spec.role = `lyra_${mark._id}`;
     return manipulators(mark, spec);

--- a/src/js/store/factory/marks/Text.ts
+++ b/src/js/store/factory/marks/Text.ts
@@ -21,11 +21,11 @@ export const Text = Record<LyraTextMark>({
     update: {
       dx: {value: 0, offset: 0},
       dy: {value: 0, offset: 0},
-      text: {value: 'Text'},
+      text: {signal: 'Text'},
       align: {value: 'center'},
       baseline: {value: 'middle'},
       font: {value: 'Helvetica'},
-      fontSize: {value: 14},
+      fontSize: {value: 12},
       fontStyle: {value: 'normal'},
       fontWeight: {value: 'normal'},
       angle: {value: 0}


### PR DESCRIPTION
`AutoComplete` is the component that allows us to manipulate fields and text together as part of expression functions. This PR conducts an initial refactor to move away from Vega 2's handlebar text templates and instead produce anonymous signal expressions. 

A post-EuroVis todo is to re-enabling autocomplete so that fields can be added simply by typing rather than only via drag-and-drop.

![image](https://user-images.githubusercontent.com/42262/68217195-3466f380-ffb0-11e9-8e32-91ff311d5593.png)
