### PR TITLE
Scattered fixes to get aggregation working again.

### DIFF
--- a/src/js/actions/bindChannel/index.ts
+++ b/src/js/actions/bindChannel/index.ts
@@ -59,7 +59,7 @@ export default function bindChannel(dsId: number, field, markId: number, propert
   return function(dispatch, getState) {
     const state = getState(),
       mark: MarkRecord = getInVis(state, 'marks.' + markId),
-      markType = mark.get('type'),
+      markType = mark.type,
       spec = vlSpec(mark),
       mapping = map(spec),
       channel = channelName(property),
@@ -91,6 +91,7 @@ export default function bindChannel(dsId: number, field, markId: number, propert
     parseScales(dispatch, state, parsed);
     parseMarks(dispatch, state, parsed);
 
+    // TODO:
     // if (parsed.map.data.summary) {
     //   updateAggregateDependencies(dispatch, getState(), parsed);
     // }

--- a/src/js/actions/pipelineActions.ts
+++ b/src/js/actions/pipelineActions.ts
@@ -48,7 +48,7 @@ export function aggregatePipeline (id: number, aggregate: LyraAggregateTransform
     const state: State = getState();
     const pipeline: PipelineRecord = getInVis(state, 'pipelines.' + id);
     const srcId = pipeline._source;
-    const srcSchema: Schema = getInVis(state, 'datasets.' + srcId + '._schema').toJS();
+    const srcSchema: Schema = getInVis(state, 'datasets.' + srcId + '._schema');
     const schema = dsUtil.aggregateSchema(srcSchema, aggregate);
     const key = (aggregate.groupby as string[]).join('|'); // TODO: vega 2 aggregate.groupby is string[]
 

--- a/src/js/components/encodings/GuideList.tsx
+++ b/src/js/components/encodings/GuideList.tsx
@@ -79,7 +79,7 @@ class GuideList extends React.Component<OwnProps & StateProps & DispatchProps> {
         </li>
 
         {props.guides.map(function(guide) {
-          const guideId = guide.get('_id');
+          const guideId = guide._id;
           let scaleId;
           if (guide._gtype === GuideType.Axis) {
             guide = guide as AxisRecord;
@@ -89,7 +89,7 @@ class GuideList extends React.Component<OwnProps & StateProps & DispatchProps> {
             scaleId = guide[guide._type];
           }
           const name = capitalize(props.scales.getIn([scaleId, 'name']));
-          const type = capitalize(guide.get('_gtype'));
+          const type = capitalize(guide._gtype);
 
           return (
             <li key={guideId}>

--- a/src/js/components/inspectors/Rect.tsx
+++ b/src/js/components/inspectors/Rect.tsx
@@ -1,9 +1,9 @@
 'use strict';
 
 import * as React from 'react';
+import {PrimType} from '../../constants/primTypes';
 import {ExtentProperty} from './ExtentProperty';
 import {Property} from './Property';
-import {PrimType} from '../../constants/primTypes';
 
 interface RectInspectorProps {
   primId: number,

--- a/src/js/components/pipelines/AggregateField.tsx
+++ b/src/js/components/pipelines/AggregateField.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
+import {AggregateOp} from 'vega';
 import {ColumnRecord} from '../../store/factory/Dataset';
 import {AggregateHandlers} from './AggregateList';
 
 const AGGREGATE_OPS = require('../../constants/aggregateOps');
 
 interface OwnProps extends AggregateHandlers {
-  op: any; // propTypes.oneOf(AGGREGATE_OPS).isRequired,
+  op: AggregateOp;
   field: ColumnRecord
 }
 

--- a/src/js/components/pipelines/AggregateList.tsx
+++ b/src/js/components/pipelines/AggregateList.tsx
@@ -19,11 +19,10 @@ interface OwnProps {
 interface OwnState {
   fullList: boolean;
 }
-class TransformsList extends React.Component<OwnProps, OwnState> {
+export class AggregateList extends React.Component<OwnProps, OwnState> {
 
   constructor(props) {
     super(props);
-
     this.state = {fullList: false};
   }
   public componentWillReceiveProps(newProps: OwnProps) {
@@ -32,7 +31,7 @@ class TransformsList extends React.Component<OwnProps, OwnState> {
     }
   }
 
-  public expand() {
+  public expand = () => {
     this.setState({fullList: true});
   }
 
@@ -56,5 +55,3 @@ class TransformsList extends React.Component<OwnProps, OwnState> {
     );
   }
 }
-
-export default TransformsList;

--- a/src/js/components/pipelines/DataTable.tsx
+++ b/src/js/components/pipelines/DataTable.tsx
@@ -56,12 +56,7 @@ class DataTable extends React.Component<OwnProps & StateProps & {className?: str
     };
   }
 
-  private $table;
-
-  public componentDidMount() {
-    const el = d3.select(ReactDOM.findDOMNode(this));
-    this.$table = el.select('.datatable');
-  };
+  private $table: any = React.createRef();
 
   public shouldComponentUpdate(nextProps: OwnProps & StateProps, nextState: OwnState) {
     const vega = nextProps.vega;
@@ -69,15 +64,13 @@ class DataTable extends React.Component<OwnProps & StateProps & {className?: str
   }
 
   public prevPage = () => {
-    const node = this.$table.node();
     this.setState({page: this.state.page - 1});
-    node.scrollLeft = 0;
+    this.$table.current.scrollLeft = 0;
   }
 
   public nextPage = () => {
-    const node = this.$table.node();
     this.setState({page: this.state.page + 1});
-    node.scrollLeft = 0;
+    this.$table.current.scrollLeft = 0;
   }
 
   public showHoverField = (evt) => {
@@ -113,7 +106,7 @@ class DataTable extends React.Component<OwnProps & StateProps & {className?: str
     const keys = schema.keySeq().toArray();
     const max = output.length;
     const fmt = dl.format.auto.number();
-    const scrollLeft = this.$table && this.$table.node().scrollLeft;
+    const scrollLeft = this.$table.current && this.$table.current.scrollLeft;
 
     const prev = page > 0 ? (
       <Icon glyph={assets.prev} width='10' height='10' onClick={this.prevPage} />
@@ -129,7 +122,7 @@ class DataTable extends React.Component<OwnProps & StateProps & {className?: str
         <TransformList dsId={id} />
 
         {output.length ? (
-          <div className='datatable'
+          <div className='datatable' ref={this.$table}
             onMouseLeave={this.hideHover} onScroll={this.hideHover}>
 
             <table>

--- a/src/js/components/pipelines/HoverField.tsx
+++ b/src/js/components/pipelines/HoverField.tsx
@@ -9,7 +9,7 @@ import {ColumnRecord, Schema} from '../../store/factory/Dataset';
 import {CELL, MODE, SELECTED} from '../../store/factory/Signal';
 import duplicate from '../../util/duplicate';
 import {Icon} from '../Icon';
-import AggregateList from './AggregateList';
+import {AggregateList} from './AggregateList';
 import FieldType from './FieldType';
 import FilterIcon from './transforms/FilterIcon';
 import FormulaIcon from './transforms/FormulaIcon';
@@ -91,12 +91,10 @@ class HoverField extends React.Component<OwnProps & StateProps & DispatchProps, 
   public handleDragStart = (evt) => {
     const classList = evt.target.classList;
     this.setState((currentState) => {
-      // if an AggregateField isn't being dragged, close the menu
-      if (!classList.contains('aggregate-field')) {
-        return {...currentState, bindField: duplicate(this.state.fieldDef), showAggregates: false}
-      }
-      else {
-        return {...currentState, bindField: duplicate(this.state.fieldDef)};
+      return {
+        ...currentState,
+        bindField: duplicate(this.state.fieldDef),
+        showAggregates: classList.contains('aggregate-field')  // if an AggregateField isn't being dragged, close the menu
       }
     });
 

--- a/src/js/constants/aggregateOps.js
+++ b/src/js/constants/aggregateOps.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = [
-  'mean', 'median', 'min', 'max', 'sum', 'count', 'distinct', 'valid',
-  'missing', 'q1', 'q3', 'variance', 'variancep', 'stdev', 'stdevp',
-  'modeskew'
+  'count', 'mean', 'sum', 'min', 'max',
+  'variance', 'variancep', 'stdev', 'stdevp',
+  'median', 'q1', 'q3', 'modeskew'
 ];

--- a/src/js/reducers/pipelinesReducer.ts
+++ b/src/js/reducers/pipelinesReducer.ts
@@ -32,7 +32,7 @@ export function pipelinesReducer(state: PipelineState, action: ActionType<typeof
 
   if (action.type === getType(pipelineActions.baseAggregatePipeline)) {
     const p = action.payload;
-    return state.setIn([id, '_aggregates', p.key], p.dsId);
+    return state.setIn([str(id), '_aggregates', p.key], p.dsId);
   }
 
   // TODO: this code is unused

--- a/src/js/store/factory/Dataset.ts
+++ b/src/js/store/factory/Dataset.ts
@@ -42,6 +42,7 @@ export type LyraUrlDataset = LyraDatasetProperties & UrlData;
 
 export const Dataset = Record<LyraDataset>({
   _id: null, _parent: null, _schema: null, name: null,
+  source: null,
   transform: []
 });
 export type DatasetRecord = RecordOf<LyraDataset>;


### PR DESCRIPTION
Currently, Webpack fails at correctly compiling Vega-Lite's reference to `fast-json-stable-stringify` which is an ES6 import statement of a CommonJS module. 

Pending a more thorough investigation/overhaul of our build system, we will need to dig into `node_modules/vega-lite/src/util.ts` and replace [the import](https://github.com/vega/vega-lite/blob/master/src/util.ts#L4) with an old-style CommonJS `require`:

```js
const stableStringify = require('fast-json-stable-stringify');
```

