### PR TITLE
Esefah/legend inspector

### DIFF
--- a/src/js/components/inspectors/Legend.tsx
+++ b/src/js/components/inspectors/Legend.tsx
@@ -95,9 +95,9 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
             <div className='property-group'>
               {/* <h3>Gradient</h3> */}
 
-              {/* <Property name={grad + 'height'} label="Height" type="number" {...props} /> */}
+              {/* <Property name={grad + 'height'} label="Height" type="number" onChange={handleChange} {...props} /> */}
 
-              {/* <Property name={grad + 'width'} label="Width" type="number" {...props} /> */}
+              {/* <Property name={grad + 'width'} label="Width" type="number" onChange={handleChange} {...props} /> */}
 
               <MoreProperties label='Gradient' header='true'>
                 <Property name={grad + 'stroke.value'} label='Color' type='color'  onChange={handleChange} {...props} />

--- a/src/js/components/inspectors/Legend.tsx
+++ b/src/js/components/inspectors/Legend.tsx
@@ -40,20 +40,20 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
     const legendType = props.legendType;
     const scaleType = props.scaleType;
     const orientOpts = ['left', 'right'];
-    const legend   = 'properties.legend.';
-    const title  = 'properties.title.';
-    const labels = 'properties.labels.';
-    const grad = 'properties.gradient.';
-    const symbols = 'properties.symbols.';
+    const legend   = 'encode.legend.update.';
+    const title  = 'encode.title.update.';
+    const labels = 'encode.labels.update.';
+    const grad = 'encode.gradient.update.';
+    const symbols = 'encode.symbols.update.';
 
     const labelProperties = (
       <div className='property-group'>
         <h3>Labels</h3>
 
-        <Property name={labels + 'fontSize'} label='Font Size' type='number' {...props} />
+        <Property name={labels + 'fontSize.value'} label='Font Size' type='number'  onChange={handleChange} {...props} />
 
         <MoreProperties label='Label'>
-          <Property name={labels + 'fill'} label='Fill' type='color' {...props} />
+          <Property name={labels + 'fill.value'} label='Fill' type='color'  onChange={handleChange} {...props} />
         </MoreProperties>
       </div>
     );
@@ -80,10 +80,10 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
           <Property name='title' label='Text' type='text'
             onChange={handleChange} {...props} />
 
-          <Property name={title + 'fontSize'} label='Font Size' type='number' {...props} />
+          <Property name={title + 'fontSize.value'} label='Font Size' type='number' onChange={handleChange} {...props} />
 
           <MoreProperties label='Title'>
-            <Property name={title + 'fill'} label='Color' type='color' {...props} />
+            <Property name={title + 'fill.value'} label='Color' type='color' onChange={handleChange} {...props} />
           </MoreProperties>
         </div>
 
@@ -100,10 +100,10 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
               {/* <Property name={grad + 'width'} label="Width" type="number" {...props} /> */}
 
               <MoreProperties label='Gradient' header='true'>
-                <Property name={grad + 'stroke'} label='Color' type='color' {...props} />
+                <Property name={grad + 'stroke.value'} label='Color' type='color'  onChange={handleChange} {...props} />
 
-                <Property name={grad + 'strokeWidth'} label='Width' type='range'
-                  min='0' max='10' step='0.25' {...props} />
+                <Property name={grad + 'strokeWidth.value'} label='Width' type='range'
+                  min='0' max='10' step='0.25'  onChange={handleChange} {...props} />
               </MoreProperties>
             </div>
           </div>
@@ -113,28 +113,28 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
               <h3>Symbols</h3>
 
               {legendType !== 'shape' ? (
-                <Property name={symbols + 'shape'} label='Shape'
-                  type='select' opts={SymbolShapes} {...props} />
+                <Property name={symbols + 'shape.value'} label='Shape'
+                  type='select' opts={SymbolShapes}  onChange={handleChange} {...props} />
               ) : null}
 
               {legendType !== 'size' ? (
-                <Property name={symbols + 'size'} label='Size' type='number' {...props} />
+                <Property name={symbols + 'size.value'} label='Size' type='number'  onChange={handleChange} {...props} />
               ) : null}
 
               {legendType !== 'fill' ? (
-                <Property name={symbols + 'fill'} label='Fill' type='color' {...props} />
+                <Property name={symbols + 'fill.value'} label='Fill' type='color'  onChange={handleChange} {...props} />
               ) : null}
 
               {legendType !== 'stroke' ? (
-                <Property name={symbols + 'stroke'} label='Stroke' type='color' {...props} />
+                <Property name={symbols + 'stroke.value'} label='Stroke' type='color'  onChange={handleChange} {...props} />
               ) : null}
 
               <MoreProperties label='Symbol'>
-                <Property name={symbols + 'fillOpacity'} label='Opacity'
-                  type='range' min='0' max='1' step='0.05' {...props} />
+                <Property name={symbols + 'fillOpacity.value'} label='Opacity'
+                  type='range' min='0' max='1' step='0.05'  onChange={handleChange} {...props} />
 
-                <Property name={symbols + 'strokeWidth'} label='Width'
-                  type='range' min='0' max='10' step='0.25' {...props} />
+                <Property name={symbols + 'strokeWidth.value'} label='Width'
+                  type='range' min='0' max='10' step='0.25'  onChange={handleChange} {...props} />
               </MoreProperties>
             </div>
 

--- a/src/js/components/inspectors/MoreProperties.tsx
+++ b/src/js/components/inspectors/MoreProperties.tsx
@@ -37,25 +37,25 @@ class BaseMoreProperties extends React.Component<MorePropsProps, MorePropsState>
       moreLink = (
         <div>
           <h3 className='show-more-props more-props-label'
-            onClick={this.handleClick} style={style1}>
+            onClick={(e) => this.handleClick(e)} style={style1}>
             + {props.label}</h3>
 
           <h3 className='hide-more-props more-props-label'
-            onClick={this.handleClick} style={style0}>
+            onClick={(e) => this.handleClick(e)} style={style0}>
             — {props.label}</h3>
         </div>
       );
     } else {
       moreLink = (
         <a className='show-more-props more-props-label' href='#'
-          onClick={this.handleClick} style={style1}>
+          onClick={(e) => this.handleClick(e)} style={style1}>
           + More {props.label} Properties
         </a>
       );
 
       fewerLink = (
         <a className='hide-more-props more-props-label' href='#'
-          style={style0} onClick={this.handleClick}>
+          style={style0} onClick={(e) => this.handleClick(e)}>
           – Fewer {props.label} Properties
         </a>
       );

--- a/src/js/reducers/guidesReducer.ts
+++ b/src/js/reducers/guidesReducer.ts
@@ -35,7 +35,7 @@ export function guidesReducer(state: GuideState, action: ActionType<typeof guide
   }
 
   if (action.type === getType(guideActions.updateGuideProperty)) {
-    return state.setIn([str(id), action.payload.property], fromJS(action.payload.value));
+    return state.setIn([str(id), ...action.payload.property.split(".")], fromJS(action.payload.value));
   }
 
   if (action.type === getType(scaleActions.deleteScale)) {

--- a/src/js/store/factory/Guide.ts
+++ b/src/js/store/factory/Guide.ts
@@ -62,7 +62,9 @@ export const Legend = Record<LyraLegend>({
   symbolFillColor: '#ffffff',
   symbolOpacity: 1,
   strokeColor: '#ffffff',
-  encode: {}
+  encode: {},
+  title: null,
+  orient: null
 }, 'LyraLegend');
 
 export type LegendRecord = RecordOf<LyraLegend>;


### PR DESCRIPTION
Fixes #477. 
- Updated syntax in Legend.tsx to reflect new Vega syntax. Mainly properties -> encode. and added .value to the property names.
- Added change listeners to the inputs.
- Fixed the "this" bug in MoreProperties component.
- Fixed use of setIn in guideReducer to reflect updated use of how to pass property names.
- Added missing properties to legend record.

Submitting for code review. 

Only issue currently is that I am getting this warning:
Warning: A component is changing an uncontrolled input of type range to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.

Looking into this.

