### PR TITLE
Area Orientation selector

### DIFF
--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -1,10 +1,12 @@
 'use strict';
 const INTERPOLATE = require('../../constants/interpolate');
+const getInVis = require('../../util/immutable-utils').getInVis;
 
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {PrimType} from '../../constants/primTypes';
 import {Property} from './Property';
+import {State} from '../../store';
 
 const Area = {
   'ORIENT': [
@@ -12,12 +14,22 @@ const Area = {
     'horizontal'
 ]};
 
-interface AreaProps {
+interface OwnProps {
   primId: number,
   primType: PrimType
 }
 
-class BaseArea extends React.Component<AreaProps> {
+interface StateProps {
+  orient: string;
+}
+
+function mapStateToProps(reduxState: State, ownProps: OwnProps): StateProps {
+  const primId = ownProps.primId;
+  return {
+    orient: getInVis(reduxState, `signals.lyra_area_${primId}_orient.value`)
+  };
+}
+class BaseArea extends React.Component<OwnProps & StateProps> {
   public render() {
     const props = this.props;
     return (
@@ -29,17 +41,32 @@ class BaseArea extends React.Component<AreaProps> {
             opts={Area.ORIENT} {...props} />
         </div>
 
-        <Property name='x' type='number' droppable={true} {...props}>
-          <h3 className='label'>X Position</h3>
-        </Property>
+        {props.orient === 'vertical' ?
+            <Property name='x' type='number' droppable={true} {...props}>
+              <h3 className='label'>X Position</h3>
+            </Property>
 
-        <div className='property-group'>
-          <h3>Y Position</h3>
+          : <div className='property-group'>
+              <h3>X Position</h3>
 
-          <Property name='y' label='Start' type='number' droppable={true} {...props} />
+              <Property name='x' label='Start' type='number' droppable={true} {...props} />
 
-          <Property name='y2' label='End' type='number' droppable={true} {...props} />
-        </div>
+              <Property name='x2' label='End' type='number' droppable={true} {...props} />
+            </div>
+        }
+
+        {props.orient === 'vertical' ?
+            <div className='property-group'>
+              <h3>Y Position</h3>
+
+              <Property name='y' label='Start' type='number' droppable={true} {...props} />
+
+              <Property name='y2' label='End' type='number' droppable={true} {...props} />
+            </div>
+          :  <Property name='y' type='number' droppable={true} {...props}>
+                <h3 className='label'>Y Position</h3>
+              </Property>
+        }
 
         <div className='property-group'>
           <h3>Fill</h3>
@@ -74,4 +101,4 @@ class BaseArea extends React.Component<AreaProps> {
     );
   }
 };
-export const AreaInspector = connect()(BaseArea);
+export const AreaInspector = connect(mapStateToProps)(BaseArea);

--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -6,6 +6,12 @@ import {connect} from 'react-redux';
 import {PrimType} from '../../constants/primTypes';
 import {Property} from './Property';
 
+const Area = {
+  'ORIENT': [
+    'vertical',
+    'horizontal'
+]};
+
 interface AreaProps {
   primId: number,
   primType: PrimType
@@ -16,12 +22,12 @@ class BaseArea extends React.Component<AreaProps> {
     const props = this.props;
     return (
       <div>
-        {/* <div className="property-group">
+        <div className="property-group">
           <h3>Orientation</h3>
 
           <Property name="orient" label="Orient" type="select"
             opts={Area.ORIENT} {...props} />
-        </div>*/}
+        </div>
 
         <Property name='x' type='number' droppable={true} {...props}>
           <h3 className='label'>X Position</h3>

--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 import {PrimType} from '../../constants/primTypes';
 import {Property} from './Property';
+import {ExtentProperty} from './ExtentProperty';
 import {State} from '../../store';
 
 const Area = {
@@ -48,20 +49,21 @@ class BaseArea extends React.Component<OwnProps & StateProps> {
 
           : <div className='property-group'>
               <h3>X Position</h3>
+              {console.log("...props", props)}
+              <ExtentProperty exType='x' {...props} />
+              {/* <Property name='x' label='Start' type='number' droppable={true} {...props} />
 
-              <Property name='x' label='Start' type='number' droppable={true} {...props} />
-
-              <Property name='x2' label='End' type='number' droppable={true} {...props} />
+              <Property name='x2' label='End' type='number' droppable={true} {...props} /> */}
             </div>
         }
 
         {props.orient === 'vertical' ?
             <div className='property-group'>
               <h3>Y Position</h3>
+              <ExtentProperty exType='y' {...props} />
+              {/* <Property name='y' label='Start' type='number' droppable={true} {...props} />
 
-              <Property name='y' label='Start' type='number' droppable={true} {...props} />
-
-              <Property name='y2' label='End' type='number' droppable={true} {...props} />
+              <Property name='y2' label='End' type='number' droppable={true} {...props} /> */}
             </div>
           :  <Property name='y' type='number' droppable={true} {...props}>
                 <h3 className='label'>Y Position</h3>

--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -49,11 +49,7 @@ class BaseArea extends React.Component<OwnProps & StateProps> {
 
           : <div className='property-group'>
               <h3>X Position</h3>
-              {console.log("...props", props)}
               <ExtentProperty exType='x' {...props} />
-              {/* <Property name='x' label='Start' type='number' droppable={true} {...props} />
-
-              <Property name='x2' label='End' type='number' droppable={true} {...props} /> */}
             </div>
         }
 
@@ -61,9 +57,7 @@ class BaseArea extends React.Component<OwnProps & StateProps> {
             <div className='property-group'>
               <h3>Y Position</h3>
               <ExtentProperty exType='y' {...props} />
-              {/* <Property name='y' label='Start' type='number' droppable={true} {...props} />
 
-              <Property name='y2' label='End' type='number' droppable={true} {...props} /> */}
             </div>
           :  <Property name='y' type='number' droppable={true} {...props}>
                 <h3 className='label'>Y Position</h3>

--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -26,8 +26,9 @@ interface StateProps {
 
 function mapStateToProps(reduxState: State, ownProps: OwnProps): StateProps {
   const primId = ownProps.primId;
+  const orientSignal = reduxState.getIn(['vis', 'present', 'marks', String(primId), 'encode', 'update', 'orient', 'signal']);
   return {
-    orient: getInVis(reduxState, `signals.lyra_area_${primId}_orient.value`)
+    orient: reduxState.getIn(['vis', 'present', 'signals', orientSignal, 'value'])
   };
 }
 class BaseArea extends React.Component<OwnProps & StateProps> {
@@ -35,33 +36,27 @@ class BaseArea extends React.Component<OwnProps & StateProps> {
     const props = this.props;
     return (
       <div>
-        <div className="property-group">
+        {/* Decided not to expose  orientation as the expected behavior is unclear */}
+        {/* <div className="property-group">
           <h3>Orientation</h3>
 
           <Property name="orient" label="Orient" type="select"
             opts={Area.ORIENT} {...props} />
-        </div>
+        </div> */}
 
+        <h3 className='label'>X Position</h3>
         {props.orient === 'vertical' ?
-            <Property name='x' type='number' droppable={true} {...props}>
-              <h3 className='label'>X Position</h3>
-            </Property>
+            <Property name='x' type='number' droppable={true} {...props} />
 
-          : <div className='property-group'>
-              <h3>X Position</h3>
-              <ExtentProperty exType='x' {...props} />
-            </div>
+          :
+            <ExtentProperty exType='x' {...props} />
         }
 
+        <h3>Y Position</h3>
         {props.orient === 'vertical' ?
-            <div className='property-group'>
-              <h3>Y Position</h3>
-              <ExtentProperty exType='y' {...props} />
-
-            </div>
-          :  <Property name='y' type='number' droppable={true} {...props}>
-                <h3 className='label'>Y Position</h3>
-              </Property>
+            <ExtentProperty exType='y' {...props} />
+          :
+            <Property name='y' type='number' droppable={true} {...props} />
         }
 
         <div className='property-group'>

--- a/src/js/components/inspectors/Area.tsx
+++ b/src/js/components/inspectors/Area.tsx
@@ -1,6 +1,5 @@
 'use strict';
 const INTERPOLATE = require('../../constants/interpolate');
-const getInVis = require('../../util/immutable-utils').getInVis;
 
 import * as React from 'react';
 import {connect} from 'react-redux';
@@ -9,11 +8,12 @@ import {Property} from './Property';
 import {ExtentProperty} from './ExtentProperty';
 import {State} from '../../store';
 
-const Area = {
-  'ORIENT': [
-    'vertical',
-    'horizontal'
-]};
+// Needed for orient selector
+// const Area = {
+//   'ORIENT': [
+//     'vertical',
+//     'horizontal'
+// ]};
 
 interface OwnProps {
   primId: number,

--- a/src/js/store/factory/marks/Area.ts
+++ b/src/js/store/factory/marks/Area.ts
@@ -19,8 +19,12 @@ export const Area = Record<LyraAreaMark>({
   from: null,
   encode: {
     update: {
-      // x2: {value: 0},
+      x2: {value: 0},
       y2: {value: 250},
+      xc: {value: 70, _disabled: true},
+      yc: {value: 70, _disabled: true},
+      width: {value: 40, _disabled: true},
+      height: {value: 40, _disabled: true},
       tension: {value: 13},
       interpolate: {value: 'monotone'},
       orient: {value: 'vertical'}

--- a/src/js/store/factory/marks/Area.ts
+++ b/src/js/store/factory/marks/Area.ts
@@ -19,7 +19,7 @@ export const Area = Record<LyraAreaMark>({
   from: null,
   encode: {
     update: {
-      x2: {value: 0},
+      x2: {value: 250},
       y2: {value: 250},
       xc: {value: 70, _disabled: true},
       yc: {value: 70, _disabled: true},


### PR DESCRIPTION
Original purpose:  Expose Vega orientation property to Lyra user in area inspector.  Decided not to add this feature.  The components are there and commented out, in case we decide to add it in later.


Changes proposed in this pull request:
- Commented out orientation selector for users to select either 'horizontal' or 'vertical' orientation.
- Added initial values to area mark
- Used <extendProperty> as opposed to hard-coded y and y2 to match rect component
- Switches which properties are editable (e.g. x2, y2)  in the area inspector if orientation is switched (leaving it set to vertical though)


