### PR TITLE
Default axis title and orient options

### DIFF
--- a/src/js/actions/bindChannel/parseGuides.ts
+++ b/src/js/actions/bindChannel/parseGuides.ts
@@ -123,11 +123,11 @@ function findOrCreateAxis(dispatch: ThunkDispatch<State, any, any>, state: State
   if (count < 2) {
     let axis = Guide(GuideType.Axis, parsed.channel, scaleId) as AxisRecord;
     axis = axis.mergeDeep({
-      title: def[0].title,
+      title: def[1].title,
       // zindex: def[0].zindex,
       grid: def.length > 1,
-      orient: count === 1 && prevOrient ? SWAP_ORIENT[prevOrient] : def[0].orient || axis.orient,
-      encode: def[0].encode
+      orient: count === 1 && prevOrient ? SWAP_ORIENT[prevOrient] : def[1].orient || axis.orient,
+      encode: def[1].encode
     });
 
     const axisId = assignId(dispatch, state);

--- a/src/js/components/inspectors/Axis.tsx
+++ b/src/js/components/inspectors/Axis.tsx
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import {MoreProperties} from './MoreProperties';
 import {Property} from './Property';
 import {PrimType} from '../../constants/primTypes';
+import {State} from '../../store';
 
 interface AxisProps {
   primId: number,
@@ -12,7 +13,17 @@ interface AxisProps {
   handleChange: (evt) => void
 }
 
-class BaseAxisInspector extends React.Component<AxisProps> {
+interface StateProps {
+  orient: string;
+}
+
+function mapStateToProps(reduxState: State, ownProps: AxisProps): StateProps {
+  const primId = ownProps.primId;
+  return {
+    orient: reduxState.getIn(['vis', 'present', 'guides', String(primId),'orient'])
+  };
+}
+class BaseAxisInspector extends React.Component<StateProps & AxisProps> {
 
   public render() {
     const props = this.props;
@@ -31,7 +42,7 @@ class BaseAxisInspector extends React.Component<AxisProps> {
           <h3>Axis</h3>
 
           <Property name='orient' label='Orient' type='select'
-            opts={orientOpts} onChange={handleChange} {...props} />
+            opts={props.orient == 'top' || props.orient == 'bottom' ? orientOpts.slice(0,2) : orientOpts.slice(2,4)} onChange={handleChange} {...props} />
 
           <MoreProperties label='Axis'>
             <Property name={axis + 'stroke.value'} label='Color' type='color' onChange={handleChange} {...props} />
@@ -112,4 +123,4 @@ class BaseAxisInspector extends React.Component<AxisProps> {
   }
 };
 
-export const AxisInspector = connect()(BaseAxisInspector);
+export const AxisInspector = connect(mapStateToProps)(BaseAxisInspector);

--- a/src/js/components/inspectors/Axis.tsx
+++ b/src/js/components/inspectors/Axis.tsx
@@ -14,13 +14,16 @@ interface AxisProps {
 }
 
 interface StateProps {
-  orient: string;
+  scaleName: string;
 }
 
 function mapStateToProps(reduxState: State, ownProps: AxisProps): StateProps {
   const primId = ownProps.primId;
+  const guide = reduxState.getIn(['vis', 'present', 'guides', String(primId)]);
+  const scaleId = guide.get("scale");
+  const scale = reduxState.getIn(['vis', 'present', 'scales', scaleId]);
   return {
-    orient: reduxState.getIn(['vis', 'present', 'guides', String(primId),'orient'])
+    scaleName: scale.name
   };
 }
 class BaseAxisInspector extends React.Component<StateProps & AxisProps> {
@@ -42,7 +45,7 @@ class BaseAxisInspector extends React.Component<StateProps & AxisProps> {
           <h3>Axis</h3>
 
           <Property name='orient' label='Orient' type='select'
-            opts={props.orient == 'top' || props.orient == 'bottom' ? orientOpts.slice(0,2) : orientOpts.slice(2,4)} onChange={handleChange} {...props} />
+            opts={props.scaleName === 'x' ? orientOpts.slice(0,2) : orientOpts.slice(2,4)} onChange={handleChange} {...props} />
 
           <MoreProperties label='Axis'>
             <Property name={axis + 'stroke.value'} label='Color' type='color' onChange={handleChange} {...props} />


### PR DESCRIPTION
Populate the default axis title from the parsed Vega def

Changes proposed in this pull request:
- Select the parsed Vega axis def that corresponds to the data-bound axis
- Restricts axis orientation options to top and bottom for x axis and left and right for y axis

