### PR TITLE
connecting some guide inspector properties

### DIFF
--- a/src/js/components/inspectors/Axis.tsx
+++ b/src/js/components/inspectors/Axis.tsx
@@ -66,7 +66,10 @@ class BaseAxisInspector extends React.Component<StateProps & AxisProps> {
           <MoreProperties label='Title'>
             <Property name={title + 'fill.value'} label='Color' type='color' onChange={handleChange} {...props} />
 
-            <Property name='titleOffset' label='Offset' type='number'
+            <Property name={title + 'dx.value'} label='dx Offset' type='number'
+              onChange={handleChange} {...props} />
+            
+            <Property name={title + 'dy.value'} label='dy Offset' type='number'
               onChange={handleChange} {...props} />
           </MoreProperties>
         </div>

--- a/src/js/components/inspectors/Axis.tsx
+++ b/src/js/components/inspectors/Axis.tsx
@@ -117,9 +117,6 @@ class BaseAxisInspector extends React.Component<StateProps & AxisProps> {
             <Property name={ticks + 'strokeWidth.value'} label='Width' type='range'
               min='0' max='10' step='0.25' onChange={handleChange} {...props} />
 
-            <Property name='tickPadding' label='Padding' type='range'
-              onChange={handleChange} {...props} />
-
             <Property name='tickSize' label='Size' type='number'
               onChange={handleChange} {...props} />
           </MoreProperties>

--- a/src/js/components/inspectors/Legend.tsx
+++ b/src/js/components/inspectors/Legend.tsx
@@ -130,7 +130,7 @@ class BaseLegendInspector extends React.Component<OwnProps & StateProps> {
               ) : null}
 
               <MoreProperties label='Symbol'>
-                <Property name={symbols + 'fillOpacity.value'} label='Opacity'
+                <Property name={symbols + 'opacity.value'} label='Opacity'
                   type='range' min='0' max='1' step='0.05'  onChange={handleChange} {...props} />
 
                 <Property name={symbols + 'strokeWidth.value'} label='Width'

--- a/src/js/store/factory/Guide.ts
+++ b/src/js/store/factory/Guide.ts
@@ -47,7 +47,9 @@ export const Axis = Record<LyraAxis>({
     title: {
       update: {
         fontSize: {value: 10},
-        fill: {value: '#000000'}
+        fill: {value: '#000000'},
+        dx: {value: 0},
+        dy: {value: 0}
       }
     },
     labels: {
@@ -93,7 +95,6 @@ export const Legend = Record<LyraLegend>({
   strokeWidth: null,
   strokeDash: null,
   symbolFillColor: '#ffffff',
-  symbolOpacity: 1,
   strokeColor: '#ffffff',
   titleFontSize: 10,
   encode: {
@@ -113,6 +114,12 @@ export const Legend = Record<LyraLegend>({
       update: {
         fontSize: {value: 10},
         fill: {value: '#000000'}
+      }
+    },    
+    symbols: {
+      update: {
+        strokeWidth: { value: 1 },
+        opacity: {value: 1}
       }
     }
   },


### PR DESCRIPTION
- fill gradient issue is covered in https://github.com/vega/lyra/pull/497/files. sorry didn't see this in time.
- looks like tick padding isn't really a thing unless I am missing the vega lite equivalent.
- changing title offset to dx offset and dy offset